### PR TITLE
fix: only show results with score > 0.5, fix tests, avoid console error

### DIFF
--- a/src/constants/constants.ts
+++ b/src/constants/constants.ts
@@ -13,8 +13,8 @@ export const NUMBER_OF_FILTER_OPTIONS = 40;
 export const READABLE_TO_ELASTIC_FILTER_NAMES: { [prop in Avo.Search.FilterProp]: string } = {
 	query: 'query',
 	type: 'administrative_type',
-	educationLevel: 'lom_typical_age_range',
-	domain: 'lom_context',
+	educationLevel: 'lom_context',
+	domain: 'lom_typical_age_range', // broken // TODO VIAA
 	broadcastDate: 'dcterms_issued',
 	language: 'lom_languages',
 	keyword: 'lom_keywords',

--- a/src/modules/item/service.ts
+++ b/src/modules/item/service.ts
@@ -1,7 +1,7 @@
 import axios, { AxiosResponse } from 'axios';
 import _ from 'lodash';
 import { RecursiveError } from '../../helpers/recursiveError';
-import {Avo} from '@viaa/avo2-types';
+import { Avo } from '@viaa/avo2-types';
 
 interface ElasticsearchResponse {
 	took: number;
@@ -168,8 +168,11 @@ export function convertArrayProperties(elasticSearchResult: ElasticsearchResult)
 			if (_.isString(elasticSearchResult[stringArrayProperty])) {
 				itemResponse[stringArrayProperty] = JSON.parse(elasticSearchResult[stringArrayProperty]);
 			} else if (!_.isArray(elasticSearchResult[stringArrayProperty])) {
-				// TODO log this to VIAA log pipeline
-				console.error('Expected string array in elasticsearch response for property ', stringArrayProperty, elasticSearchResult);
+
+				if (!_.isNil(elasticSearchResult[stringArrayProperty])) {
+					// TODO log this to VIAA log pipeline
+					console.error('Expected string array in elasticsearch response for property ', stringArrayProperty, elasticSearchResult);
+				}
 				itemResponse[stringArrayProperty] = [];
 			}
 		} catch (err) {

--- a/src/modules/search/queryBuilder.ts
+++ b/src/modules/search/queryBuilder.ts
@@ -32,8 +32,6 @@ export default class QueryBuilder {
 			const queryObject: any = {};
 			delete queryObject.default; // Side effect of importing a json file as a module
 
-			queryObject.min_score = 0.5;
-
 			// Avoid huge queries
 			queryObject.size = Math.min(searchRequest.size || 30, MAX_NUMBER_SEARCH_RESULTS);
 			const max = Math.max(0, MAX_COUNT_SEARCH_RESULTS - queryObject.size);
@@ -47,6 +45,12 @@ export default class QueryBuilder {
 
 			// Specify the aggs objects with optional search terms
 			_.set(queryObject, 'aggs', this.buildAggsObject(searchRequest.filterOptionSearch));
+
+			// If search terms are passed, we're only interested in items with a score > 0
+			// If only filters are passed, and no search terms, then score 0 items are also accepted
+			if (searchRequest.filters && searchRequest.filters.query) {
+				queryObject.min_score = 0.5;
+			}
 
 			return queryObject;
 		} catch (err) {

--- a/src/modules/search/queryBuilder.ts
+++ b/src/modules/search/queryBuilder.ts
@@ -32,6 +32,8 @@ export default class QueryBuilder {
 			const queryObject: any = {};
 			delete queryObject.default; // Side effect of importing a json file as a module
 
+			queryObject.min_score = 0.5;
+
 			// Avoid huge queries
 			queryObject.size = Math.min(searchRequest.size || 30, MAX_NUMBER_SEARCH_RESULTS);
 			const max = Math.max(0, MAX_COUNT_SEARCH_RESULTS - queryObject.size);

--- a/src/modules/search/search.spec.ts
+++ b/src/modules/search/search.spec.ts
@@ -2,23 +2,13 @@ import 'jest';
 import aggregations from './fixtures/aggregations.json';
 import SearchService  from './service';
 import {Avo} from '@viaa/avo2-types';
-
-const keys: string[] = [
-	'lom_keywords.filter',
-	'dc_titles_serie.filter',
-	'lom_classification.filter',
-	'lom_typical_age_range.filter',
-	'administrative_type.filter',
-	'lom_languages',
-	'lom_context.filter',
-	'original_cp.filter',
-];
+import { AGGS_PROPERTIES } from '../../constants/constants';
 
 test('should simplify aggregation object correctly', async () => {
 	const filterOptions: Avo.Search.FilterOptions = SearchService.simplifyAggregations(aggregations);
 	expect(filterOptions).toBeObject();
-	expect(filterOptions).toContainAllKeys([...keys, 'default']); // Side affect of import json module
-	keys.forEach((key) => {
+	expect(filterOptions).toContainAllKeys([...AGGS_PROPERTIES]);
+	AGGS_PROPERTIES.forEach((key) => {
 		expect(filterOptions[key]).toBeArray();
 		filterOptions[key].forEach((optionsObj) => {
 			expect(optionsObj).toBeObject();

--- a/src/modules/search/service.ts
+++ b/src/modules/search/service.ts
@@ -226,6 +226,10 @@ export default class SearchService {
 	public static simplifyAggregations(aggregations: Aggregations): Avo.Search.FilterOptions {
 		const simpleAggs: Avo.Search.FilterOptions = {};
 		_.forEach(aggregations, (value, prop) => {
+			const cleanProp = prop.replace(/\.filter$/, '');
+			if (!ELASTIC_TO_READABLE_FILTER_NAMES[cleanProp]) {
+				console.error(`elasticsearch filter name not found for ${cleanProp}`);
+			}
 			if (_.isPlainObject(value.buckets)) {
 				// range bucket object (eg: fragment_duration_seconds)
 				const rangeBuckets = value.buckets as {
@@ -235,7 +239,7 @@ export default class SearchService {
 						doc_count: number;
 					};
 				};
-				simpleAggs[ELASTIC_TO_READABLE_FILTER_NAMES[prop]] = (_.map(rangeBuckets, (bucketValue, bucketName): SimpleBucket => {
+				simpleAggs[ELASTIC_TO_READABLE_FILTER_NAMES[cleanProp]] = (_.map(rangeBuckets, (bucketValue, bucketName): SimpleBucket => {
 					return {
 						option_name: bucketName,
 						option_count: bucketValue.doc_count,
@@ -244,7 +248,7 @@ export default class SearchService {
 			} else {
 				// regular bucket array (eg: administrative_type)
 				const regularBuckets = (value.buckets || value[prop].buckets) as { key: string, doc_count: number }[];
-				simpleAggs[ELASTIC_TO_READABLE_FILTER_NAMES[prop]] = (_.map(regularBuckets, (bucketValue): SimpleBucket => {
+				simpleAggs[ELASTIC_TO_READABLE_FILTER_NAMES[cleanProp]] = (_.map(regularBuckets, (bucketValue): SimpleBucket => {
 					return {
 						option_name: bucketValue.key,
 						option_count: bucketValue.doc_count,


### PR DESCRIPTION
fix:
* proxy service test suite
* only show results if `_score` is > 0.5 if search terms were entered
* switch educationLevel from `lom_typical_age_range` to `lom_context`
* avoid console.error when aggregation value is null

closes: 
* https://district01.atlassian.net/browse/AVO2-402
* https://district01.atlassian.net/browse/AVO2-403