### PR TITLE
feat: add trace id to graphql queries

### DIFF
--- a/server/src/modules/data/controller.ts
+++ b/server/src/modules/data/controller.ts
@@ -1,23 +1,36 @@
 import DataService from './service';
 import _ from 'lodash';
+import { IncomingHttpHeaders } from 'http';
+import { logger } from '../../shared/helpers/logger';
 
 export default class DataController {
 
-	public static async execute(query: string, variables: { [varName: string]: any }): Promise<any> {
-		let data = await DataService.execute(query, variables);
-		data = this.filterAppMetaData(data);
-		return data;
+	public static async execute(query: string, variables: { [varName: string]: any }, allHeaders: IncomingHttpHeaders): Promise<any> {
+		// Copy trace id from nginx proxy to a header that hasura will understand
+		// TODO check if trace id header is correct
+		logger.info(`data route headers:
+${JSON.stringify(allHeaders, null, 2)}`);
+		const traceId = allHeaders['x-viaa-trace-id-header'] as string | undefined;
+		const headers: { [headerName: string]: string } = {};
+		if (traceId) {
+			headers['x-hasura-trace-id'] = traceId;
+		}
+
+		// Execute the graphql query
+		let response = await DataService.execute(query, variables, headers);
+		response = this.filterAppMetaData(response);
+		return response;
 	}
 
 	/**
 	 * Filters items that are deleted or orphaned and adds errors
-	 * @param data response from graphql
+	 * @param response response from graphql
 	 */
-	private static filterAppMetaData(data: any): { items: any[], errors: string[] } {
-		const items = _.get(data, 'data.app_item_meta');
+	private static filterAppMetaData(response: any): { items: any[], errors: string[] } {
+		const items = _.get(response, 'data.app_item_meta');
 		if (items && items.length) {
 			const errors: string[] = [];
-			data.data.app_item_meta = _.compact((items || []).map((item: any) => {
+			response.data.app_item_meta = _.compact((items || []).map((item: any) => {
 				delete item.app_item_meta;
 				if (item.is_deleted) {
 					errors.push('DELETED');
@@ -26,13 +39,13 @@ export default class DataController {
 				return item;
 			}));
 			if (errors && errors.length) {
-				data.errors = errors.map((error: string) => {
+				response.errors = errors.map((error: string) => {
 					return {
 						message: error,
 					};
 				});
 			}
 		}
-		return data;
+		return response;
 	}
 }

--- a/server/src/modules/data/route.ts
+++ b/server/src/modules/data/route.ts
@@ -1,4 +1,4 @@
-import { Path, POST } from 'typescript-rest';
+import { Context, Path, POST, ServiceContext } from 'typescript-rest';
 import DataController from './controller';
 import { CustomError } from '../../shared/helpers/error';
 
@@ -9,6 +9,8 @@ interface DataQuery {
 
 @Path('/data')
 export default class DataRoute {
+	@Context
+	context: ServiceContext;
 
 	/**
 	 * Endpoint that is proxied to the graphql server so the client can collect data
@@ -18,7 +20,7 @@ export default class DataRoute {
 	@POST
 	async post(body: DataQuery): Promise<any> {
 		try {
-			return await DataController.execute(body.query, body.variables);
+			return await DataController.execute(body.query, body.variables, this.context.request.headers);
 		} catch (err) {
 			throw new CustomError('Failed to get data from graphql');
 		}

--- a/server/src/modules/data/service.ts
+++ b/server/src/modules/data/service.ts
@@ -2,13 +2,14 @@ import axios, { AxiosResponse } from 'axios';
 import { CustomError } from '../../shared/helpers/error';
 
 export default class DataService {
-	public static async execute(query: string, variables: {[varName: string]: any}): Promise<any> {
+	public static async execute(query: string, variables: {[varName: string]: any}, headers: {[headerName: string]: string} = {}): Promise<any> {
 		let url;
 		try {
 			url = process.env.GRAPHQL_URL;
 			const response: AxiosResponse<any> = await axios(url, {
 				method: 'post',
 				headers: {
+					...headers,
 					'x-hasura-admin-secret': process.env.GRAPHQL_SECRET,
 				},
 				data: {


### PR DESCRIPTION
The nginx for avo adds a unique trace id header to every request that comes into viaa
This header needs to be forwarded to the graphql instance, so logging entries can be linked to the incoming request.
This is a POC since we can only verify this once we push this to QAS and then use the remote url (which doesn't exist yet) for the client app to trigger an event.