### PR TITLE
feat(data): add retrieve errors when getting assignments

### DIFF
--- a/server/src/modules/auth/controller.ts
+++ b/server/src/modules/auth/controller.ts
@@ -34,7 +34,6 @@ export default class AuthController {
 
 	public static setLdapUserOnSession(request: Express.Request, ldapUser: LdapUser | null): void {
 		if (request.session) {
-			request.session.ldapUser = ldapUser;
 			_.set(request, 'session.ldapUser', ldapUser);
 		} else {
 			throw new CustomError(
@@ -67,6 +66,26 @@ export default class AuthController {
 			(user as any).permissions = Array.from(permissions);
 			delete user.profiles;
 			return user as any;
+		} catch (err) {
+			throw new CustomError('Failed to get user info in controller', err);
+		}
+	}
+
+	public static getUserInfoFromSession(request: Express.Request): Avo.User.User | null {
+		return _.get(request, 'session.userInfo', null);
+	}
+
+	public static setUserInfoOnSession(request: Express.Request, userInfo: Avo.User.User): void {
+		try {
+			if (request.session) {
+				_.set(request, 'session.userInfo', userInfo);
+			} else {
+				throw new CustomError(
+					'Failed to store session during setUserInfoOnSession because no session was found on request',
+					null,
+					{ userInfo },
+				);
+			}
 		} catch (err) {
 			throw new CustomError('Failed to get user info in controller', err);
 		}

--- a/server/src/modules/auth/route.ts
+++ b/server/src/modules/auth/route.ts
@@ -25,6 +25,7 @@ export default class AuthRoute {
 			if (AuthController.isAuthenticated(this.context.request)) {
 				logger.info('check login: user is authenticated');
 				const userInfo = await AuthController.getUserInfo(this.context.request);
+				AuthController.setUserInfoOnSession(this.context.request, userInfo);
 				return {
 					userInfo,
 					message: 'LOGGED_IN',

--- a/server/src/modules/data/route.ts
+++ b/server/src/modules/data/route.ts
@@ -2,6 +2,7 @@ import { Context, Path, POST, PreProcessor, ServiceContext } from 'typescript-re
 import DataController from './controller';
 import { CustomError } from '../../shared/helpers/error';
 import { isAuthenticated } from '../../shared/middleware/is-authenticated';
+import AuthController from '../auth/controller';
 
 interface DataQuery {
 	query: any;
@@ -22,7 +23,12 @@ export default class DataRoute {
 	@PreProcessor(isAuthenticated)
 	async post(body: DataQuery): Promise<any> {
 		try {
-			return await DataController.execute(body.query, body.variables, this.context.request.headers);
+			return await DataController.execute(
+				body.query,
+				body.variables,
+				this.context.request.headers,
+				AuthController.getUserInfoFromSession(this.context.request)
+			);
 		} catch (err) {
 			throw new CustomError('Failed to get data from graphql', err, { ...body });
 		}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1710840/66560430-adad2b00-eb57-11e9-9588-3f5c9860ee3a.png)


Je kan dit enkel testen door in te loggen met een andere account dan de account die de opdracht gemaakt heeft, want de owner mag altijd de opdracht bekijken.

De types errors zijn:
```
export enum AssignmentRetrieveError {
	DELETED = 'DELETED',
	NOT_YET_AVAILABLE = 'NOT_YET_AVAILABLE',
	PAST_DEADLINE = 'PAST_DEADLINE',
}
```