### PR TITLE
fix(event-logging): default to localhost for event generated inside viaa

### DIFF
--- a/server/src/modules/event-logging/controller.ts
+++ b/server/src/modules/event-logging/controller.ts
@@ -11,7 +11,7 @@ export default class EventLoggingController {
 		try {
 			logEvents = _.compact(clientEvents.map((clientEvent: ClientEvent): LogEvent | null => {
 				return {
-					subject_ip: ip,
+					subject_ip: ip || '127.0.0.1',
 					component: 'webapp',
 					namespace: 'avo',
 					action: clientEvent.action,


### PR DESCRIPTION
Walter:
> ip ontbreekt nog precies
> @Bert Verhelst "intern" zal niet werken je moet een ip geven
> je kan eventueel 127.0.0.1 zetten dat is zelfde als localhost