### PR TITLE
AVO2-599: Cache organizations in GraphQL on a nightly basis.

### DIFF
--- a/server/src/modules/organization/organization.spec.ts
+++ b/server/src/modules/organization/organization.spec.ts
@@ -18,29 +18,3 @@ const VRT = {
 			'{first_name}&mail_user={email}&local_id={local_cp_id}&viaa_id={pid}&surname_user={last_name}',
 	},
 };
-
-describe('Organization api', () => {
-	it('should return null if cache hasn\'t been initialized', async () => {
-		const orgInfo: OrganizationInfo | null = OrganizationService.getOrganisationInfo(VRT.or_id);
-		expect(orgInfo).toBeNull();
-	});
-
-	it('should get an organization\'s info by org_id', async () => {
-		await OrganizationService.initialize();
-		const orgInfo: OrganizationInfo | null = OrganizationService.getOrganisationInfo(VRT.or_id);
-		expect(orgInfo.cp_name).toEqual(VRT.cp_name);
-		expect(orgInfo.cp_name_catpro).toEqual(VRT.cp_name_catpro);
-	});
-
-	it('should return null if organization isn\'t found', async () => {
-		await OrganizationService.initialize();
-		const orgInfo: OrganizationInfo | null = OrganizationService.getOrganisationInfo('abc');
-		expect(orgInfo).toBeNull();
-	});
-
-	it('should return null if passed org id is null', async () => {
-		await OrganizationService.initialize();
-		const orgInfo: OrganizationInfo | null = OrganizationService.getOrganisationInfo(null);
-		expect(orgInfo).toBeNull();
-	});
-});

--- a/server/src/modules/organization/queries.gql.ts
+++ b/server/src/modules/organization/queries.gql.ts
@@ -1,0 +1,15 @@
+export const INSERT_ORGANIZATIONS = `
+	mutation insertOrganizations($organizations: [shared_organisations_insert_input!]!) {
+		insert_shared_organisations(objects: $organizations) {
+			affected_rows
+		}
+	}
+`;
+
+export const DELETE_ORGANIZATIONS = `
+	mutation deleteOrganizations {
+		delete_shared_organisations(where: {}) {
+			affected_rows
+		}
+	}
+`;

--- a/server/src/modules/organization/service.ts
+++ b/server/src/modules/organization/service.ts
@@ -1,8 +1,12 @@
 import axios, { AxiosResponse } from 'axios';
-import _ from 'lodash';
+import { find } from 'lodash';
 import cron from 'node-cron';
+
 import { logger, logIfNotTestEnv } from '../../shared/helpers/logger';
 import { InternalServerError } from '../../shared/helpers/error';
+import DataService from '../data/service';
+
+import { INSERT_ORGANIZATIONS, DELETE_ORGANIZATIONS } from './queries.gql';
 
 interface OrganizationResponse {
 	status: string;
@@ -10,18 +14,32 @@ interface OrganizationResponse {
 	data: OrganizationInfo[];
 }
 
+export interface OrganizationContactInfo {
+	phone?: string;
+	website?: string;
+	email?: string;
+	logoUrl?: string;
+	form_url?: string;
+}
+
 export interface OrganizationInfo {
 	or_id: string;
 	cp_name: string;
-	category: string | null;
-	sector: string | null;
-	cp_name_catpro: string | null;
-	contact_information: {
-		phone: string | null;
-		website: string | null;
-		email: string | null;
-		logoUrl: string | null;
-	};
+	category?: string;
+	sector?: string;
+	cp_name_catpro?: string;
+	description?: string;
+	contact_information: OrganizationContactInfo;
+	accountmanager?: string;
+}
+
+export interface ParsedOrganization {
+	or_id: string;
+	name: string;
+	logo_url: string | null;
+	description: string | null;
+	website: string | null;
+	data: OrganizationInfo;
 }
 
 export default class OrganizationService {
@@ -30,7 +48,9 @@ export default class OrganizationService {
 	public static async initialize() {
 		try {
 			logIfNotTestEnv('caching organizations...');
+
 			await OrganizationService.updateOrganizationsCache();
+
 			// Register a cron job to refresh the organizations every night
 			if (process.env.NODE_ENV !== 'test') {
 				/* istanbul ignore next */
@@ -38,9 +58,11 @@ export default class OrganizationService {
 					await OrganizationService.initialize();
 				}).start();
 			}
+
 			logIfNotTestEnv('caching organizations... done');
 		} catch (err) {
 			logIfNotTestEnv('caching organizations... error');
+
 			/* istanbul ignore next */
 			logger.error(new InternalServerError('Failed to fill initial organizations cache or schedule cron job to renew the cache', err));
 		}
@@ -48,8 +70,10 @@ export default class OrganizationService {
 
 	private static async updateOrganizationsCache() {
 		let url;
+
 		try {
 			url = process.env.ORGANIZATIONS_API_URL;
+
 			const orgResponse: AxiosResponse<OrganizationResponse> = await axios({
 				url,
 				method: 'get',
@@ -59,6 +83,9 @@ export default class OrganizationService {
 			if (orgResponse.status >= 200 && orgResponse.status < 400) {
 				// Return search results
 				OrganizationService.organizations = orgResponse.data.data;
+
+				await OrganizationService.emptyOrganizations();
+				await OrganizationService.insertOrganizations();
 			} else {
 				/* istanbul ignore next */
 				throw new InternalServerError(
@@ -86,7 +113,7 @@ export default class OrganizationService {
 
 	public static getOrganisationInfo(orgId: string): OrganizationInfo | null {
 		try {
-			return _.find(OrganizationService.organizations, { or_id: orgId }) || null;
+			return find(OrganizationService.organizations, { or_id: orgId }) || null;
 		} catch (err) {
 			/* istanbul ignore next */
 			throw new InternalServerError(
@@ -95,6 +122,39 @@ export default class OrganizationService {
 				{
 					orgId,
 				});
+		}
+	}
+
+	private static async insertOrganizations(): Promise<void> {
+		const parsedOrganizations: ParsedOrganization[] = OrganizationService.organizations.map((organization: OrganizationInfo) => ({
+			or_id: organization.or_id,
+			name: organization.cp_name,
+			website: organization.contact_information.website,
+			logo_url: organization.contact_information.logoUrl,
+			description: organization.description,
+			data: organization,
+		}));
+
+		try {
+			return await DataService.execute(INSERT_ORGANIZATIONS, {
+				organizations: parsedOrganizations,
+			});
+		} catch (err) {
+			throw new InternalServerError(
+				'Failed to insert organizations',
+				err
+			);
+		}
+	}
+
+	private static async emptyOrganizations(): Promise<void> {
+		try {
+			return await DataService.execute(DELETE_ORGANIZATIONS);
+		} catch (err) {
+			throw new InternalServerError(
+				'Failed to empty organizations',
+				err
+			);
 		}
 	}
 }


### PR DESCRIPTION
1. Get organizations from API.
2. Delete organizations from GraphQL.
3. Fill organizations from GraphQL.