### PR TITLE
fix(registration-flow): fix issues with registration, add test stamboek

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -947,9 +947,9 @@
       "integrity": "sha512-te5lMAWii1uEJ4FwLjzdlbw3+n0FZNOvFXHxQDKeT0dilh7HOzdMzV2TrJVUzq8ep7J4Na8OUYPRLSQkJHAlrg=="
     },
     "@viaa/avo2-types": {
-      "version": "2.4.0",
-      "resolved": "http://do-prd-mvn-01.do.viaa.be:8081/repository/npm-viaa/@viaa/avo2-types/-/avo2-types-2.4.0.tgz",
-      "integrity": "sha512-D6ZzNBTh9AQVO1fB5qB7/TURkhKGXhrG0eHK3sCk/D81DBRY0CPfkYlqiGWbTKh1t3OYYjHWRw+jwTUPqLM5XA=="
+      "version": "2.6.1",
+      "resolved": "http://do-prd-mvn-01.do.viaa.be:8081/repository/npm-viaa/@viaa/avo2-types/-/avo2-types-2.6.1.tgz",
+      "integrity": "sha512-SH6ZG368Dylc9OcIKK6F/QMSMDl6eIR5ukEyhGu6oKyPti6xlCDJvQ300lFWnJ8afw3o2B+qpBPZbkwzM2LHiw=="
     },
     "@wry/context": {
       "version": "0.4.4",

--- a/server/package.json
+++ b/server/package.json
@@ -31,7 +31,7 @@
     "@hapi/joi": "15.1.1",
     "@studiohyperdrive/logger": "1.1.1",
     "@types/hapi__joi": "15.0.3",
-    "@viaa/avo2-types": "^2.5.0",
+    "@viaa/avo2-types": "^2.6.1",
     "apollo-boost": "^0.4.4",
     "async": "3.1.0",
     "axios": "0.19.0",

--- a/server/src/modules/auth/controller.ts
+++ b/server/src/modules/auth/controller.ts
@@ -61,7 +61,12 @@ export default class AuthController {
 	}
 
 	public static async createProfile(profile: Partial<Avo.User.Profile>): Promise<string> {
-		const response = await DataService.execute(INSERT_PROFILE, { profile });
+		const profileWithLocation = _.extend({
+			location: 'nvt',
+			alias: null,
+			avatar: null,
+		}, profile);
+		const response = await DataService.execute(INSERT_PROFILE, { profile: profileWithLocation });
 		if (!response) {
 			throw new InternalServerError(
 				'Failed to create avo user profile. Response from insert request was undefined',
@@ -69,7 +74,7 @@ export default class AuthController {
 				{ insertProfileResponse: response, query: INSERT_PROFILE });
 		}
 
-		const profileId = _.get(response, 'data.insert_shared_users.returning[0].uid');
+		const profileId = _.get(response, 'data.insert_users_profiles.returning[0].id');
 		if (_.isNil(profileId)) {
 			throw new InternalServerError(
 				'Failed to create avo user profile. Response from insert request didn\'t contain a uid',

--- a/server/src/modules/stamboek-validate/controller.ts
+++ b/server/src/modules/stamboek-validate/controller.ts
@@ -24,6 +24,9 @@ export default class StamboekController {
 	public static async validate(stamboekNumber: string): Promise<StamboekValidationStatuses> {
 		try {
 			// Check if valid stamboek number through external klasse api
+			if (stamboekNumber === '97436428856') { // allow debug stamboek number to be used multiple times for testing purposes
+				return 'VALID';
+			}
 			const isValid = await StamboekService.validate(stamboekNumber);
 			if (isValid) {
 				// check if already in use in our local db

--- a/server/src/modules/stamboek-validate/controller.ts
+++ b/server/src/modules/stamboek-validate/controller.ts
@@ -24,7 +24,8 @@ export default class StamboekController {
 	public static async validate(stamboekNumber: string): Promise<StamboekValidationStatuses> {
 		try {
 			// Check if valid stamboek number through external klasse api
-			if (stamboekNumber === '97436428856') { // allow debug stamboek number to be used multiple times for testing purposes
+			if (process.env.STAMBOEK_FAKE_TEST_NUMBER && stamboekNumber === process.env.STAMBOEK_FAKE_TEST_NUMBER) {
+				// allow debug stamboek number to be used multiple times for testing purposes
 				return 'VALID';
 			}
 			const isValid = await StamboekService.validate(stamboekNumber);


### PR DESCRIPTION
Allow teachers to register

Import notes for testing:
* you can register using your own email address
* if you want to try multiple times, you can add a "." character in your gmail emailaddress which creates an alias. Email will still be received on your regular gmail address (eg: ve.rhelstbert@gmail.com)
* Do not use a "+" sign, since the ldap database can't handle this and the ssum registration page of viaa doesn't correctly escape the + char
* For the stamboekNumber, you can use the stamboek number in 1password under "viaa test stamboek number"