### PR TITLE
fix(auth): redirect to error page if no avo group + added action buttons

### DIFF
--- a/server/src/modules/auth/controller.ts
+++ b/server/src/modules/auth/controller.ts
@@ -129,7 +129,8 @@ export default class AuthController {
 		if ((avoUserInfo.idpmaps || []).includes(idpType)) {
 			return redirectToClientErrorPage(
 				`Je account is reeds gelinked met ${idpType.toLowerCase()}. Unlink je account eerst van je andere smartschool account`,
-				'link'
+				'link',
+					['home', 'helpdesk'],
 			);
 		}
 
@@ -138,7 +139,8 @@ export default class AuthController {
 		if (!idpLoginPath) {
 			return redirectToClientErrorPage(
 				'Dit platform kan nog niet gelinked worden aan uw account',
-				'link'
+				'link',
+				['home', 'helpdesk'],
 			);
 		}
 
@@ -170,6 +172,7 @@ export default class AuthController {
 			return redirectToClientErrorPage(
 				'Het linken van de account is mislukt (database error)',
 				'alert-triangle',
+				['home', 'helpdesk'],
 				error.identifier
 			);
 		}
@@ -189,6 +192,7 @@ export default class AuthController {
 			return redirectToClientErrorPage(
 				`Er ging iets mis bij het unlinken van de ${idpType.toLowerCase()} account`,
 				'alert-triangle',
+				['home', 'helpdesk'],
 				error.identifier
 			);
 		}

--- a/server/src/modules/auth/idps/smartschool/route.ts
+++ b/server/src/modules/auth/idps/smartschool/route.ts
@@ -36,6 +36,7 @@ export default class SmartschoolRoute {
 			return redirectToClientErrorPage(
 				'Er ging iets mis tijdens het inloggen met smartschool',
 				'alert-triangle',
+				['home', 'helpdesk'],
 				error.identifier
 			);
 		}
@@ -50,7 +51,8 @@ export default class SmartschoolRoute {
 				const errorMessage = SMARTSCHOOL_ERROR_MESSAGES[(userOrError as LoginErrorResponse).error];
 				return redirectToClientErrorPage(
 					errorMessage,
-					'alert-triangle'
+					'alert-triangle',
+					['home', 'helpdesk'],
 				);
 			}
 
@@ -70,7 +72,8 @@ export default class SmartschoolRoute {
 				if (!response.avoUser) {
 					return redirectToClientErrorPage(
 						'Gelieve eerst in te loggen met je avo account en je smartschool te koppelen in je account instellingen',
-						'link'
+						'link',
+						['home', 'helpdesk'],
 					);
 				}
 				IdpHelper.setIdpUserInfoOnSession(this.context.request, response.smartschoolUserInfo, 'SMARTSCHOOL');
@@ -84,6 +87,7 @@ export default class SmartschoolRoute {
 			return redirectToClientErrorPage(
 				'Er ging iets mis na het inloggen met smartschool',
 				'alert-triangle',
+				['home', 'helpdesk'],
 				error.identifier
 			);
 		}
@@ -101,6 +105,7 @@ export default class SmartschoolRoute {
 			return redirectToClientErrorPage(
 				'Er ging iets mis tijdens het uitloggen met smartschool',
 				'alert-triangle',
+				['home', 'helpdesk'],
 				error.identifier
 			);
 		}

--- a/server/src/modules/auth/route.ts
+++ b/server/src/modules/auth/route.ts
@@ -61,6 +61,7 @@ export default class AuthRoute {
 			return redirectToClientErrorPage(
 				'Er ging iets mis tijdens het uitloggen',
 				'alert-triangle',
+				['home', 'helpdesk'],
 				error.identifier
 			);
 		}
@@ -95,6 +96,7 @@ export default class AuthRoute {
 			return redirectToClientErrorPage(
 				'Het koppelen van de account is mislukt',
 				'alert-triangle',
+				['home', 'helpdesk'],
 				error.identifier,
 			);
 		}
@@ -122,6 +124,7 @@ export default class AuthRoute {
 			return redirectToClientErrorPage(
 				'Het ontkoppelen van de account is mislukt',
 				'alert-triangle',
+				['home', 'helpdesk'],
 				error.identifier
 			);
 		}

--- a/server/src/shared/helpers/error-redirect-client.ts
+++ b/server/src/shared/helpers/error-redirect-client.ts
@@ -1,10 +1,18 @@
 import { Return } from 'typescript-rest';
 import * as queryString from 'querystring';
 
-export function redirectToClientErrorPage(message: string, icon: string = 'alert-triangle', identifier?: string) {
+export type ErrorActionButton = 'home' | 'helpdesk'; // TODO use type in typings repo
+
+export function redirectToClientErrorPage(
+	message: string,
+	icon: string = 'alert-triangle',
+	actionButtons: ErrorActionButton[] = [],
+	identifier?: string
+) {
 	return new Return.MovedTemporarily<void>(`${process.env.CLIENT_HOST}/error?${queryString.stringify({
 		message,
 		icon,
+		actionButtons: actionButtons.join(','),
 		...(identifier ? { identifier } : {}), // If no hard error object exists, there will not be an identifier
 	})}`);
 }


### PR DESCRIPTION
This PR checks if the user's ldap account has the avo application in its allowed apps
and it also adds action buttons for all error view redirects

This PR has a client twin: https://github.com/viaacode/avo2-client/pull/372

![image](https://user-images.githubusercontent.com/1710840/73740479-8f8fba00-4748-11ea-95d9-90473d508d92.png)
