### PR TITLE
fix(auth): add avo app by id instead of name through ldap api

### DIFF
--- a/server/src/modules/auth/idps/hetarchief/controller.ts
+++ b/server/src/modules/auth/idps/hetarchief/controller.ts
@@ -109,8 +109,8 @@ export default class HetArchiefController {
 	}
 
 	private static async addAvoAppToLdap(ldapObject: LdapUser): Promise<void> {
-		let url: string | undefined = undefined;
-		let data: any | undefined = undefined;
+		let url: string = undefined;
+		let data: any = undefined;
 		try {
 			// Request avo be added to ldap apps through ldap api
 			const ldapUuid = _.get(ldapObject, 'attributes.entryUUID[0]');

--- a/server/src/modules/auth/idps/hetarchief/controller.ts
+++ b/server/src/modules/auth/idps/hetarchief/controller.ts
@@ -109,19 +109,17 @@ export default class HetArchiefController {
 	}
 
 	private static async addAvoAppToLdap(ldapObject: LdapUser): Promise<void> {
+		let url: string | undefined = undefined;
+		let data: any | undefined = undefined;
 		try {
-			const hasAvoApp = _.get(ldapObject, 'attributes.apps', []).includes('avo');
-			if (hasAvoApp) {
-				return;
-			}
 			// Request avo be added to ldap apps through ldap api
 			const ldapUuid = _.get(ldapObject, 'attributes.entryUUID[0]');
 			if (!ldapUuid) {
 				throw new InternalServerError('Failed to get uuid from ldap object');
 			}
-			const url = `${process.env.LDAP_API_ENDPOINT}/people/${ldapUuid}`;
-			const data = {
-				apps: ['avo'],
+			url = `${process.env.LDAP_API_ENDPOINT}/people/${ldapUuid}`;
+			data = {
+				apps: [(await AuthService.getLdapApps())['avo']],
 			};
 			await axios(url, {
 				data,
@@ -133,7 +131,11 @@ export default class HetArchiefController {
 			});
 			return;
 		} catch (err) {
-			throw new InternalServerError('Failed to add avo app to ldap user object', err, { ldapObject });
+			throw new InternalServerError(
+				'Failed to add avo app to ldap user object',
+				err,
+				{ ldapObject, url, data }
+				);
 		}
 	}
 }


### PR DESCRIPTION
This is a temporary fix until the ssum takes over the duties of setting ldap apps/groups