### PR TITLE
fix(auth): link accounts through ipd map instead of email

### DIFF
--- a/server/src/modules/auth/controller.ts
+++ b/server/src/modules/auth/controller.ts
@@ -10,7 +10,7 @@ import DataService from '../data/service';
 import { ExternalServerError, InternalServerError } from '../../shared/helpers/error';
 import { redirectToClientErrorPage } from '../../shared/helpers/error-redirect-client';
 
-import { DELETE_IDP_MAPS, INSERT_IDP_MAP, INSERT_PROFILE, INSERT_USER } from './queries.gql';
+import { DELETE_IDP_MAPS, INSERT_PROFILE, INSERT_USER } from './queries.gql';
 import KlascementController from './idps/klascement/controller';
 import HetArchiefController from './idps/hetarchief/controller';
 import SmartschoolController from './idps/smartschool/controller';
@@ -157,14 +157,13 @@ export default class AuthController {
 		let avoUserInfo: Avo.User.User | undefined;
 		try {
 			avoUserInfo = IdpHelper.getAvoUserInfoFromSession(request);
-			const idpMap: Partial<IdpMap> = {
-				idp: idpUserInfo.type,
-				idp_user_id: String(IDP_ADAPTERS[idpUserInfo.type].getUserId(idpUserInfo.userObject)),
-				local_user_id: avoUserInfo.uid,
-			};
 
 			// Link idp accounts to each other
-			await DataService.execute(INSERT_IDP_MAP, { idpMap });
+			await IdpHelper.createIdpMap(
+				idpUserInfo.type,
+				String(IDP_ADAPTERS[idpUserInfo.type].getUserId(idpUserInfo.userObject)),
+				avoUserInfo.uid
+			);
 			return new Return.MovedTemporarily<void>(returnToUrl);
 		} catch (err) {
 			const error = new ExternalServerError('Failed to insert the idp map to link an account', err, { avoUserInfo, idpUserInfo, returnToUrl });

--- a/server/src/modules/auth/idp-helper.ts
+++ b/server/src/modules/auth/idp-helper.ts
@@ -1,8 +1,11 @@
-import { IdpMap, IdpType } from './types';
 import _ from 'lodash';
-import { Avo } from '@viaa/avo2-types';
 import { Request } from 'express';
+
+import { Avo } from '@viaa/avo2-types';
+
 import { CustomError, InternalServerError, ServerError } from '../../shared/helpers/error';
+
+import { IdpMap, IdpType } from './types';
 import { AuthService } from './service';
 import DataService from '../data/service';
 import { INSERT_IDP_MAP, INSERT_PROFILE } from './queries.gql';

--- a/server/src/modules/auth/idps/hetarchief/controller.ts
+++ b/server/src/modules/auth/idps/hetarchief/controller.ts
@@ -1,11 +1,13 @@
-import _ from 'lodash';
-import { IdpHelper } from '../../idp-helper';
+import axios from 'axios';
 import { Request } from 'express';
+import _ from 'lodash';
+
+import { Avo } from '@viaa/avo2-types';
+
+import { IdpHelper } from '../../idp-helper';
 import { IdpType, LdapUser } from '../../types';
 import { AuthService } from '../../service';
-import { Avo } from '@viaa/avo2-types';
 import AuthController from '../../controller';
-import axios from 'axios';
 import { CustomError, InternalServerError } from '../../../../shared/helpers/error';
 import DataService from '../../../data/service';
 import { GET_USER_BY_LDAP_UUID } from '../../queries.gql';

--- a/server/src/modules/auth/idps/hetarchief/controller.ts
+++ b/server/src/modules/auth/idps/hetarchief/controller.ts
@@ -6,7 +6,9 @@ import { AuthService } from '../../service';
 import { Avo } from '@viaa/avo2-types';
 import AuthController from '../../controller';
 import axios from 'axios';
-import { InternalServerError } from '../../../../shared/helpers/error';
+import { CustomError, InternalServerError } from '../../../../shared/helpers/error';
+import DataService from '../../../data/service';
+import { GET_USER_BY_LDAP_UUID } from '../../queries.gql';
 
 const LDAP_ROLE_TO_USER_ROLE: { [ldapRole: string]: number } = {
 	Admin: 1,
@@ -52,15 +54,15 @@ export default class HetArchiefController {
 	}
 
 	public static async createUserAndProfile(req: Request, stamboekNumber: string) {
-		let idpUserInfo: LdapUser | null = null;
+		let ldapUserInfo: LdapUser | null = null;
 		try {
-			idpUserInfo = IdpHelper.getIdpUserInfoFromSession(req);
-			if (!idpUserInfo) {
+			ldapUserInfo = IdpHelper.getIdpUserInfoFromSession(req);
+			if (!ldapUserInfo) {
 				throw new InternalServerError('Failed to create user because ldap object is undefined', null);
 			}
 
 			// Create avo user object
-			const user: Partial<Avo.User.User> = this.parseLdapObject(idpUserInfo);
+			const user: Partial<Avo.User.User> = this.parseLdapObject(ldapUserInfo);
 			const existingUser = await AuthService.getAvoUserInfoByEmail(user.mail);
 			if (existingUser) {
 				throw new InternalServerError(
@@ -74,9 +76,10 @@ export default class HetArchiefController {
 			const userUuid = await AuthController.createUser(user);
 
 			// Create avo profile object
-			const profileId = await this.createProfile(idpUserInfo, userUuid, stamboekNumber);
+			const profileId = await this.createProfile(ldapUserInfo, userUuid, stamboekNumber);
 
-			await HetArchiefController.addAvoAppToLdap(idpUserInfo);
+			// Add the avo app to the list of allowed apps in ldap (this will be done by the ssum in the future)
+			await HetArchiefController.addAvoAppToLdap(ldapUserInfo);
 
 			const userInfo: Avo.User.User = await AuthService.getAvoUserInfoById(userUuid);
 			IdpHelper.setAvoUserInfoOnSession(req, userInfo);
@@ -84,9 +87,37 @@ export default class HetArchiefController {
 			// Add permission groups
 			// Users with a stamboek number are by default a "lesgever" and should be linked to that user group
 			await AuthService.addUserGroupsToProfile(2, profileId);
+
+			// Check if user is linked to hetarchief idp, if not create a link in the idp_map table
+			if (!(userInfo.idpmaps || []).includes('HETARCHIEF')) {
+				const ldapUuid = ldapUserInfo.attributes.entryUUID[0];
+				if (!ldapUuid) {
+					throw new CustomError(
+						'Failed to link user to hetarchief ldap because ldap user does not have uuid',
+						null,
+						{
+							ldapUserInfo,
+							userUuid,
+						}
+					);
+				}
+				await IdpHelper.createIdpMap('SMARTSCHOOL', ldapUserInfo.attributes.entryUUID[0], userUuid);
+			}
 		} catch (err) {
-			throw new InternalServerError('Failed to create user and profile in the avo database', err, { stamboekNumber, idpUserInfo });
+			throw new InternalServerError('Failed to create user and profile in the avo database', err, {
+				stamboekNumber,
+				ldapUserInfo,
+			});
 		}
+	}
+
+	public static async getAvoUserInfoFromDatabaseByLdapUuid(ldapUuid: string | undefined): Promise<Avo.User.User | null> {
+		const response = await DataService.execute(GET_USER_BY_LDAP_UUID, { ldapUuid });
+		const avoUser = _.get(response, 'data.users_idp_map.local_user');
+		if (!avoUser) {
+			return null;
+		}
+		return AuthService.simplifyUserObject(avoUser);
 	}
 
 	private static async createProfile(ldapObject: LdapUser, userUid: string, stamboekNumber: string): Promise<string> {
@@ -135,7 +166,7 @@ export default class HetArchiefController {
 				'Failed to add avo app to ldap user object',
 				err,
 				{ ldapObject, url, data }
-				);
+			);
 		}
 	}
 }

--- a/server/src/modules/auth/idps/smartschool/controller.ts
+++ b/server/src/modules/auth/idps/smartschool/controller.ts
@@ -1,14 +1,17 @@
-import SmartschoolService, { SmartschoolToken, SmartschoolUserInfo } from './service';
+import _ from 'lodash';
+import { Request } from 'express';
+
+import { Avo } from '@viaa/avo2-types';
+
 import DataService from '../../../data/service';
 import { GET_PROFILE_IDS_BY_USER_UID, GET_USER_BY_IDP_ID } from '../../queries.gql';
-import { Avo } from '@viaa/avo2-types';
-import _ from 'lodash';
-import { IdpType } from '../../types';
 import { IdpHelper } from '../../idp-helper';
-import { Request } from 'express';
+import { IdpType } from '../../types';
 import { AuthService } from '../../service';
 import AuthController from '../../controller';
 import { InternalServerError } from '../../../../shared/helpers/error';
+
+import SmartschoolService, { SmartschoolToken, SmartschoolUserInfo } from './service';
 
 export type SmartschoolLoginError = 'FIRST_LINK_ACCOUNT' | 'NO_ACCESS';
 export type LoginErrorResponse = { error: SmartschoolLoginError };

--- a/server/src/modules/auth/idps/smartschool/controller.ts
+++ b/server/src/modules/auth/idps/smartschool/controller.ts
@@ -1,9 +1,9 @@
 import SmartschoolService, { SmartschoolToken, SmartschoolUserInfo } from './service';
 import DataService from '../../../data/service';
-import { GET_PROFILE_IDS_BY_USER_UID, GET_USER_BY_IDP_ID, INSERT_IDP_MAP, INSERT_PROFILE, INSERT_USER } from '../../queries.gql';
+import { GET_PROFILE_IDS_BY_USER_UID, GET_USER_BY_IDP_ID } from '../../queries.gql';
 import { Avo } from '@viaa/avo2-types';
 import _ from 'lodash';
-import { IdpMap, IdpType } from '../../types';
+import { IdpType } from '../../types';
 import { IdpHelper } from '../../idp-helper';
 import { Request } from 'express';
 import { AuthService } from '../../service';
@@ -118,21 +118,6 @@ export default class SmartschoolController extends IdpHelper {
 			alias: userUid,
 		};
 		return AuthController.createProfile(profile);
-	}
-
-	private static async createIdpMap(idp: IdpType, idpUserId: string, localUserId: string) {
-		const idpMap: Partial<IdpMap> = {
-			idp,
-			idp_user_id: idpUserId,
-			local_user_id: localUserId,
-		};
-		const response = await DataService.execute(INSERT_IDP_MAP, { idpMap });
-		if (!response) {
-			throw new InternalServerError(
-				'Failed to link avo user to an idp. Response from insert request was undefined',
-				null,
-				{ response, query: INSERT_PROFILE });
-		}
 	}
 
 	private static async getUserByIdpId(idpType: IdpType, idpId: string): Promise<string | null> {

--- a/server/src/modules/auth/queries.gql.ts
+++ b/server/src/modules/auth/queries.gql.ts
@@ -122,6 +122,70 @@ query getUserInfoById($userId: uuid!) {
 }
 `;
 
+export const GET_USER_BY_LDAP_UUID = `
+query getUserByLdapUuid($ldapUuid: String!) {
+  users_idp_map(where: {idp: {_eq: HETARCHIEF}, idp_user_id: {_eq: $ldapUuid}}) {
+    local_user {
+      id
+      first_name
+      last_name
+      profiles {
+        id
+        alias
+        alternative_email
+        avatar
+        created_at
+        location
+        stamboek
+        bio
+        function
+        updated_at
+        user_id
+        profile_user_groups {
+          groups {
+            id
+            group_user_permission_groups {
+              permission_group {
+                permission_group_user_permissions {
+                  permission {
+                    label
+                  }
+                }
+              }
+            }
+          }
+        }
+        profile_classifications {
+          key
+        }
+        profile_contexts {
+          key
+        }
+        profile_organizations {
+          unit_id
+          organization_id
+        }
+      }
+      created_at
+      expires_at
+      external_uid
+      role {
+        label
+        name
+      }
+      type
+      uid
+      updated_at
+      mail
+      organisation_id
+      idpmaps {
+        idp
+      }
+    }
+  }
+}
+`;
+
 export const INSERT_USER = `
 mutation insertUser($user: shared_users_insert_input!) {
   insert_shared_users(objects: [$user]) {

--- a/server/src/modules/auth/service.ts
+++ b/server/src/modules/auth/service.ts
@@ -5,7 +5,7 @@ import {
 	GET_USER_INFO_BY_ID,
 	GET_USER_INFO_BY_USER_EMAIL,
 	LINK_USER_GROUP_TO_PROFILE,
-	UNLINK_USER_GROUP_FROM_PROFILE
+	UNLINK_USER_GROUP_FROM_PROFILE,
 } from './queries.gql';
 import { CustomError, ExternalServerError, InternalServerError } from '../../shared/helpers/error';
 import { SharedUser } from './types';


### PR DESCRIPTION
Currently when a user logs in, we link their ldap user to their avo user by email
This is bad practice since email can change. This PR makes sure users are linked through the idp_map table.

I've also included a patch, so existing users that try to login will be linked through the idp_table, by first linking them through their email. This patch can be removed in the future