### PR TITLE
feat(content-pages): add route to load content page with search results

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "avo2-proxy-server",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -817,7 +817,8 @@
     "@types/memoizee": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/@types/memoizee/-/memoizee-0.4.3.tgz",
-      "integrity": "sha512-N6QT0c9ZbEKl33n1wyoTxZs4cpN+YXjs0Aqy5Qim8ipd9PBNIPqOh/p5Pixc4601tqr5GErsdxUbfqviDfubNw=="
+      "integrity": "sha512-N6QT0c9ZbEKl33n1wyoTxZs4cpN+YXjs0Aqy5Qim8ipd9PBNIPqOh/p5Pixc4601tqr5GErsdxUbfqviDfubNw==",
+      "dev": true
     },
     "@types/mime": {
       "version": "2.0.1",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1003,9 +1003,9 @@
       "integrity": "sha512-te5lMAWii1uEJ4FwLjzdlbw3+n0FZNOvFXHxQDKeT0dilh7HOzdMzV2TrJVUzq8ep7J4Na8OUYPRLSQkJHAlrg=="
     },
     "@viaa/avo2-types": {
-      "version": "2.11.0",
-      "resolved": "http://do-prd-mvn-01.do.viaa.be:8081/repository/npm-viaa/@viaa/avo2-types/-/avo2-types-2.11.0.tgz",
-      "integrity": "sha512-UpaFwj9SjRrBvWPNGLY2h928yq7g5tXis2Ful85HGXRL3jLhm6s5hwNGLrEzzsXQc+DCa2kRBblOGJVzq/lqzA=="
+      "version": "2.13.0",
+      "resolved": "http://do-prd-mvn-01.do.viaa.be:8081/repository/npm-viaa/@viaa/avo2-types/-/avo2-types-2.13.0.tgz",
+      "integrity": "sha512-PSpo3JDJsfSXd+VR3GB5+V6mNAk4kqG5jwLXcCIL7tPLN8m3qQinlE+RnmsY1BSxh2fbjN53sIlxnccgmidKsQ=="
     },
     "@wry/context": {
       "version": "0.4.4",

--- a/server/package.json
+++ b/server/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@hapi/joi": "15.1.1",
     "@studiohyperdrive/logger": "1.1.1",
-    "@viaa/avo2-types": "^2.11.0",
+    "@viaa/avo2-types": "^2.13.0",
     "apollo-boost": "^0.4.4",
     "async": "3.1.0",
     "aws-sdk": "^2.592.0",

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -26,6 +26,7 @@ import SearchRoute from './modules/search/route';
 import DataRoute from './modules/data/route';
 import ProfileRoute from './modules/profile/route';
 import NavigationItemsRoute from './modules/navigation-items/route';
+import ContentPagesRoute from './modules/content-pages/route';
 import PlayerTicketRoute from './modules/player-ticket/route';
 import StamboekRoute from './modules/stamboek-validate/route';
 import VideoStillsRoute from './modules/video-stills/route';
@@ -118,6 +119,7 @@ export class App {
 			DataRoute,
 			ProfileRoute,
 			NavigationItemsRoute,
+			ContentPagesRoute,
 			PlayerTicketRoute,
 			VideoStillsRoute,
 			StamboekRoute,

--- a/server/src/modules/content-pages/controller.ts
+++ b/server/src/modules/content-pages/controller.ts
@@ -3,12 +3,13 @@ import _ from 'lodash';
 import * as promiseUtils from 'blend-promise-utils';
 
 import { Avo } from '@viaa/avo2-types';
+import { SearchResultItem } from '@viaa/avo2-types/types/search/index';
 
+import { logger } from '../../shared/helpers/logger';
 import { CustomError, ExternalServerError } from '../../shared/helpers/error';
 import { IdpHelper } from '../auth/idp-helper';
+
 import ContentPageService from './service';
-import { logger } from '../../shared/helpers/logger';
-import { SearchResultItem } from '@viaa/avo2-types/types/search/index';
 
 export enum SpecialPermissionGroups {
 	loggedOutUsers = -1,
@@ -156,7 +157,7 @@ export default class ContentPageController {
 			series: searchResult.dc_titles_serie,
 			type: {
 				label: searchResult.administrative_type,
-			} as any,
+			} as any, // TODO update to Avo.Core.MediaType after update to typings v2.14.0
 			collection_fragments_aggregate: {
 				aggregate: {
 					count: 0, // TODO get value into elasticsearch

--- a/server/src/modules/content-pages/controller.ts
+++ b/server/src/modules/content-pages/controller.ts
@@ -1,0 +1,172 @@
+import { Request } from 'express';
+import _ from 'lodash';
+import * as promiseUtils from 'blend-promise-utils';
+
+import { Avo } from '@viaa/avo2-types';
+
+import { CustomError, ExternalServerError } from '../../shared/helpers/error';
+import { IdpHelper } from '../auth/idp-helper';
+import ContentPageService from './service';
+import { logger } from '../../shared/helpers/logger';
+import { SearchResultItem } from '@viaa/avo2-types/types/search/index';
+
+export enum SpecialPermissionGroups {
+	loggedOutUsers = -1,
+	loggedInUsers = -2,
+}
+
+export interface MediaItemResponse { // TODO move to typings repo
+	tileData: Partial<Avo.Collection.Collection | Avo.Item.Item>;
+	count: number;
+}
+
+export default class ContentPageController {
+	public static async getContentBlockByPath(path: string, request: Request): Promise<Avo.Content.Content | null> {
+		try {
+			const user: Avo.User.User | null = IdpHelper.getAvoUserInfoFromSession(request);
+			const contentPage: Avo.Content.Content | undefined = await ContentPageService.getContentBlockByPath(path);
+
+			if (!contentPage) {
+				return null;
+			}
+
+			// Check if content page is accessible for the user who requested the content page
+			if (!_.intersection(
+				contentPage.user_group_ids,
+				[
+					..._.get(user, 'profile.userGroupIds', []),
+					user ? SpecialPermissionGroups.loggedInUsers : SpecialPermissionGroups.loggedOutUsers,
+				]
+			).length) {
+				return null;
+			}
+
+			// Check if content page contains any search query content bocks (eg: media grids)
+			await this.resolveMediaTileItems(contentPage);
+
+			return contentPage;
+		} catch (err) {
+			throw new ExternalServerError('Failed to get content page', err);
+		}
+	}
+
+	private static async resolveMediaTileItems(contentPage: Avo.Content.Content) {
+		const mediaGridBlocks = contentPage.contentBlockssBycontentId.filter(contentBlock =>
+			contentBlock.content_block_type === 'MEDIA_GRID');
+
+		if (mediaGridBlocks.length) {
+			await promiseUtils.mapLimit(mediaGridBlocks, 2, async (mediaGridBlock: any) => {
+				try {
+					let results: any[] = [];
+					// Check for search queries
+					const searchQuery = _.get(mediaGridBlock, 'variables.blockState.searchQuery.value');
+					const searchQueryLimit = _.get(mediaGridBlock, 'variables.blockState.searchQueryLimit');
+					if (searchQuery) {
+						// resolve search query to a list of results
+						const parsedSearchQuery = JSON.parse(searchQuery);
+						const searchResponse = await ContentPageService.fetchSearchQuery(
+							searchQueryLimit,
+							parsedSearchQuery.filters || {},
+							parsedSearchQuery.orderProperty || 'relevance',
+							parsedSearchQuery.orderDirection || 'desc');
+						results = (searchResponse.results || []).map(ContentPageController.mapSearchResultToItemOrCollection);
+					}
+
+					// Check for items/collections
+					const mediaItems = _.get(mediaGridBlock, 'variables.componentState');
+					if (mediaItems.length && !_.isEmpty(mediaItems[0])) {
+						results = await promiseUtils.mapLimit(mediaItems, 10, async (item: {
+							mediaItem: {
+								type: 'ITEM' | 'COLLECTION',
+								value: string
+							}
+						}) => {
+							return await ContentPageService.fetchCollectionOrItem(item.mediaItem.type, item.mediaItem.value);
+						});
+					}
+
+					_.unset(mediaGridBlock, 'variables.componentState');
+					_.unset(mediaGridBlock, 'variables.blockState.searchQuery.value');
+					_.unset(mediaGridBlock, 'variables.blockState.searchQueryLimit');
+					_.set(mediaGridBlock, 'variables.blockState.results', results);
+				} catch (err) {
+					logger.error(new CustomError(
+						'Failed to resolve media grid content',
+						err,
+						{ contentPage, mediaGridBlock }
+					));
+				}
+			});
+		}
+	}
+
+	private static mapSearchResultToItemOrCollection(searchResult: SearchResultItem): Partial<Avo.Item.Item | Avo.Collection.Collection> {
+		const isItem = searchResult.administrative_type === 'video' || searchResult.administrative_type === 'audio';
+
+		if (isItem) {
+			return {
+				external_id: searchResult.external_id,
+				title: searchResult.dc_title,
+				created_at: searchResult.dcterms_issued,
+				description: searchResult.dcterms_abstract,
+				duration: searchResult.duration_time,
+				lom_classification: searchResult.lom_classification,
+				lom_context: searchResult.lom_context,
+				lom_intended_enduser_role: searchResult.lom_intended_enduser_role,
+				lom_keywords: searchResult.lom_keywords,
+				lom_languages: searchResult.lom_languages,
+				lom_typical_age_range: searchResult.lom_typical_age_range,
+				issued: searchResult.dcterms_issued,
+				thumbnail_path: searchResult.thumbnail_path,
+				org_id: searchResult.original_cp_id,
+				organisation: {
+					name: searchResult.original_cp,
+					or_id: searchResult.original_cp_id,
+				} as Avo.Organization.Organization,
+				series: searchResult.dc_titles_serie,
+				type: {
+					label: searchResult.administrative_type,
+				} as any,
+				view_counts_aggregate: {
+					aggregate: {
+						count: searchResult.views_count,
+					},
+				},
+			} as Partial<Avo.Item.Item>;
+		}
+		return {
+			id: searchResult.id,
+			title: searchResult.dc_title,
+			created_at: searchResult.dcterms_issued,
+			description: searchResult.dcterms_abstract,
+			duration: searchResult.duration_time,
+			lom_classification: searchResult.lom_classification,
+			lom_context: searchResult.lom_context,
+			lom_intended_enduser_role: searchResult.lom_intended_enduser_role,
+			lom_keywords: searchResult.lom_keywords,
+			lom_languages: searchResult.lom_languages,
+			lom_typical_age_range: searchResult.lom_typical_age_range,
+			issued: searchResult.dcterms_issued,
+			thumbnail_path: searchResult.thumbnail_path,
+			org_id: searchResult.original_cp_id,
+			organisation: {
+				name: searchResult.original_cp,
+				or_id: searchResult.original_cp_id,
+			} as Avo.Organization.Organization,
+			series: searchResult.dc_titles_serie,
+			type: {
+				label: searchResult.administrative_type,
+			} as any,
+			collection_fragments_aggregate: {
+				aggregate: {
+					count: 0, // TODO get value into elasticsearch
+				},
+			},
+			view_counts_aggregate: {
+				aggregate: {
+					count: searchResult.views_count,
+				},
+			},
+		} as Partial<Avo.Collection.Collection>;
+	}
+}

--- a/server/src/modules/content-pages/queries.gql.ts
+++ b/server/src/modules/content-pages/queries.gql.ts
@@ -1,0 +1,74 @@
+export const GET_CONTENT_PAGE_BY_PATH = `
+	query getContentPageByPath($path: String!) {
+		app_content(where: { path: { _eq: $path } }) {
+			title
+			content_type
+			content_width
+			created_at
+			depublish_at
+			description
+			id
+			is_protected
+			is_public
+			is_published
+			publish_at
+			path
+			contentBlockssBycontentId {
+				content_block_type
+				content_id
+				created_at
+				id
+				position
+				updated_at
+				variables
+				enum_content_block_type {
+					description
+					value
+				}
+			}
+			user_group_ids
+		}
+	}
+`;
+
+export const GET_ITEM_TILE_BY_ID = `
+	query getItemTileById($id: bpchar!) {
+		obj: app_item_meta(where: { external_id: { _eq: $id } }) {
+			created_at
+			duration
+			thumbnail_path
+			title
+			type {
+				label
+			}
+			view_counts_aggregate {
+				aggregate {
+					count
+				}
+			}
+		}
+	}
+`;
+
+export const GET_COLLECTION_TILE_BY_ID = `
+	query getCollectionTileById($id: uuid!) {
+		obj: app_collections(where: {id: {_eq: $id}}) {
+			created_at
+			title
+			thumbnail_path
+			type {
+				label
+			}
+			collection_fragments_aggregate {
+				aggregate {
+					count
+				}
+			}
+			view_counts_aggregate {
+				aggregate {
+					count
+				}
+			}
+		}
+	}
+`;

--- a/server/src/modules/content-pages/route.ts
+++ b/server/src/modules/content-pages/route.ts
@@ -1,0 +1,32 @@
+import { Context, GET, Path, QueryParam, ServiceContext } from 'typescript-rest';
+
+import { Avo } from '@viaa/avo2-types';
+
+import { InternalServerError, NotFoundError } from '../../shared/helpers/error';
+
+import ContentPageController from './controller';
+
+@Path('/content-pages')
+export default class ContentPagesRoute {
+	@Context
+	context: ServiceContext;
+
+	@Path('')
+	@GET
+	async getContentPage(@QueryParam('path') path: string): Promise<Avo.Content.Content> {
+		let content: Avo.Content.Content = null;
+		try {
+			content = await ContentPageController.getContentBlockByPath(path, this.context.request);
+		} catch (err) {
+			throw new InternalServerError('Failed to get content page', err);
+		}
+		if (content) {
+			return content;
+		}
+		throw new NotFoundError(
+			'The content page was not found or you do not have rights to see it',
+			null,
+			{ path }
+			);
+	}
+}

--- a/server/src/modules/content-pages/service.ts
+++ b/server/src/modules/content-pages/service.ts
@@ -1,0 +1,59 @@
+import _ from 'lodash';
+
+import { Avo } from '@viaa/avo2-types';
+
+import { CustomError, ExternalServerError } from '../../shared/helpers/error';
+
+import DataService from '../data/service';
+import { GET_COLLECTION_TILE_BY_ID, GET_CONTENT_PAGE_BY_PATH, GET_ITEM_TILE_BY_ID } from './queries.gql';
+import { MediaItemResponse } from './controller';
+import SearchController from '../search/controller';
+
+export default class ContentPageService {
+	public static async getContentBlockByPath(path: string): Promise<Avo.Content.Content | null> {
+		try {
+			const response = await DataService.execute(GET_CONTENT_PAGE_BY_PATH, {
+				path,
+			});
+			const contentPage: Avo.Content.Content | undefined = _.get(response, 'data.app_content[0]');
+
+			return contentPage || null;
+		} catch (err) {
+			throw new ExternalServerError('Failed to get content page', err);
+		}
+	}
+
+	public static async fetchCollectionOrItem(type: 'ITEM' | 'COLLECTION', id: string): Promise<MediaItemResponse | null> {
+		try {
+			const response = await DataService.execute(type === 'ITEM' ? GET_ITEM_TILE_BY_ID : GET_COLLECTION_TILE_BY_ID, { id });
+
+			const itemOrCollection = _.get(response, 'data.obj[0]', null);
+			// const count = _.get(response, 'data.count[0]', 0); // TODO fix counts
+
+			return itemOrCollection;
+		} catch (err) {
+			throw new CustomError('Failed to fetch collection or item', err, { type, id });
+		}
+	}
+
+	public static async fetchSearchQuery(
+		limit: number,
+		filters: Partial<Avo.Search.Filters>,
+		orderProperty: Avo.Search.OrderProperty,
+		orderDirection: Avo.Search.OrderDirection,
+	): Promise<Avo.Search.Search | null> {
+		try {
+			return await SearchController.search({
+				filters,
+				orderProperty,
+				orderDirection,
+				from: 0,
+				size: limit,
+				index: 'both',
+			});
+		} catch (err) {
+
+			throw new CustomError('Failed to fetch search results for content page', err, { limit, filters });
+		}
+	}
+}

--- a/server/src/modules/klaar/controller.ts
+++ b/server/src/modules/klaar/controller.ts
@@ -27,7 +27,7 @@ interface KlaarNewsletter {
 	};
 }
 
-interface ButtonAction {
+export interface ButtonAction {
 	type: string;
 	value: string;
 }

--- a/server/src/modules/navigation-items/controller.ts
+++ b/server/src/modules/navigation-items/controller.ts
@@ -5,7 +5,7 @@ import { Avo } from '@viaa/avo2-types';
 import { IdpHelper } from '../auth/idp-helper';
 import _ from 'lodash';
 import DataService from '../data/service';
-import { GET_CONTENT_PAGE_BY_PATH, GET_NAVIGATION_ITEMS } from './queries.gql';
+import { GET_NAVIGATION_ITEMS } from './queries.gql';
 import { ExternalServerError } from '../../shared/helpers/error';
 
 interface GetNavElementsResponse {
@@ -70,31 +70,6 @@ export default class NavigationItemsController {
 			return _.groupBy(visibleItems, 'placement');
 		} catch (err) {
 			throw new ExternalServerError('Failed to get navigation items', err);
-		}
-	}
-
-	public static async getContentBlockByPath(path: string, request: Request): Promise<Avo.Content.Content | null> {
-		try {
-			const user: Avo.User.User | null = IdpHelper.getAvoUserInfoFromSession(request);
-			const response = await DataService.execute(GET_CONTENT_PAGE_BY_PATH, {
-				path,
-			});
-			const contentPage: Avo.Content.Content | undefined = _.get(response, 'data.app_content[0]');
-			if (contentPage) {
-				// Path is indeed a content page url
-				if (_.intersection(
-					contentPage.user_group_ids,
-					[
-						..._.get(user, 'profile.userGroupIds', []),
-						user ? SpecialPermissionGroups.loggedInUsers : SpecialPermissionGroups.loggedOutUsers,
-					]
-				).length) {
-					return contentPage;
-				}
-			}
-			return null;
-		} catch (err) {
-			throw new ExternalServerError('Failed to get content page', err);
 		}
 	}
 }

--- a/server/src/modules/navigation-items/queries.gql.ts
+++ b/server/src/modules/navigation-items/queries.gql.ts
@@ -17,36 +17,3 @@ export const GET_NAVIGATION_ITEMS = `
 		}
 	}
 `;
-
-export const GET_CONTENT_PAGE_BY_PATH = `
-	query getContentPageByPath($path: String!) {
-		app_content(where: { path: { _eq: $path } }) {
-			title
-			content_type
-			content_width
-			created_at
-			depublish_at
-			description
-			id
-			is_protected
-			is_public
-			is_published
-			publish_at
-			path
-			contentBlockssBycontentId {
-				content_block_type
-				content_id
-				created_at
-				id
-				position
-				updated_at
-				variables
-				enum_content_block_type {
-					description
-					value
-				}
-			}
-			user_group_ids
-		}
-	}
-`;

--- a/server/src/modules/navigation-items/route.ts
+++ b/server/src/modules/navigation-items/route.ts
@@ -1,8 +1,6 @@
-import { Context, GET, Path, QueryParam, ServiceContext } from 'typescript-rest';
+import { Context, GET, Path, ServiceContext } from 'typescript-rest';
 
-import { Avo } from '@viaa/avo2-types';
-
-import { InternalServerError, NotFoundError } from '../../shared/helpers/error';
+import { InternalServerError } from '../../shared/helpers/error';
 
 import NavigationItemsController from './controller';
 
@@ -22,24 +20,5 @@ export default class NavigationItemsRoute {
 		} catch (err) {
 			throw new InternalServerError('Failed to get navigation items', err);
 		}
-	}
-
-	@Path('content')
-	@GET
-	async getContentPage(@QueryParam('path') path: string): Promise<Avo.Content.Content> {
-		let content: Avo.Content.Content = null;
-		try {
-			content = await NavigationItemsController.getContentBlockByPath(path, this.context.request);
-		} catch (err) {
-			throw new InternalServerError('Failed to get navigation items', err);
-		}
-		if (content) {
-			return content;
-		}
-		throw new NotFoundError(
-			'The content page was not found or you do not have rights to see it',
-			null,
-			{ path }
-			);
 	}
 }


### PR DESCRIPTION
closes: https://district01.atlassian.net/browse/AVO2-1041

client twin:
https://github.com/viaacode/avo2-client/pull/464

Test urls:
* http://localhost:8080/test-media-grid-bert
* http://localhost:8080/klaar/archief

![image](https://user-images.githubusercontent.com/1710840/76783393-15743b80-67b2-11ea-938a-3bf41966480f.png)

![image](https://user-images.githubusercontent.com/1710840/76783396-16a56880-67b2-11ea-8b6b-8d3a645cd6a7.png)
