### PR TITLE
fix(search): get result item external id from _source instead of _id

### DIFF
--- a/server/src/modules/search/service.ts
+++ b/server/src/modules/search/service.ts
@@ -133,7 +133,7 @@ export default class SearchService {
 					results: _.map(_.get(esResponse, 'data.hits.hits'), (result): Avo.Search.ResultItem => {
 						return {
 							...result._source,
-							id: result._id,
+							id: result._source.external_id,
 						} as Avo.Search.ResultItem;
 					}),
 					aggregations: this.simplifyAggregations(_.get(esResponse, 'data.aggregations')),


### PR DESCRIPTION
since _id will be switched over to the item uuid