### PR TITLE
feat(auth): create user on login, set permission groups

### DIFF
--- a/server/src/modules/auth/idps/hetarchief/controller.ts
+++ b/server/src/modules/auth/idps/hetarchief/controller.ts
@@ -128,7 +128,7 @@ export default class HetArchiefController {
 
 	public static async getAvoUserInfoFromDatabaseByLdapUuid(ldapUuid: string | undefined): Promise<Avo.User.User | null> {
 		const response = await DataService.execute(GET_USER_BY_LDAP_UUID, { ldapUuid });
-		const avoUser = _.get(response, 'data.users_idp_map.local_user');
+		const avoUser = _.get(response, 'data.users_idp_map[0].local_user');
 		if (!avoUser) {
 			return null;
 		}

--- a/server/src/modules/auth/idps/hetarchief/controller.ts
+++ b/server/src/modules/auth/idps/hetarchief/controller.ts
@@ -12,12 +12,13 @@ import { CustomError, InternalServerError } from '../../../../shared/helpers/err
 import DataService from '../../../data/service';
 import { GET_USER_BY_LDAP_UUID } from '../../queries.gql';
 
-const LDAP_ROLE_TO_USER_ROLE: { [ldapRole: string]: number } = {
-	Admin: 1,
-	User: 2,
-	Docent: 3,
-	// Pupils do net have an ldap object
-};
+export interface BasicIdpUserInfo {
+	first_name: string;
+	last_name: string;
+	mail: string;
+	organisation_id: string;
+	roles: string[];
+}
 
 export default class HetArchiefController {
 	public static isLoggedIn(request: Request): boolean {
@@ -55,7 +56,7 @@ export default class HetArchiefController {
 		return await AuthService.getAvoUserInfoByEmail(email);
 	}
 
-	public static async createUserAndProfile(req: Request, stamboekNumber: string) {
+	public static async createUserAndProfile(req: Request, stamboekNumber: string | null): Promise<Avo.User.User> {
 		let ldapUserInfo: LdapUser | null = null;
 		try {
 			ldapUserInfo = IdpHelper.getIdpUserInfoFromSession(req);
@@ -64,18 +65,18 @@ export default class HetArchiefController {
 			}
 
 			// Create avo user object
-			const user: Partial<Avo.User.User> = this.parseLdapObject(ldapUserInfo);
-			const existingUser = await AuthService.getAvoUserInfoByEmail(user.mail);
+			const ldapUser: BasicIdpUserInfo = this.parseLdapObject(ldapUserInfo);
+			const existingUser = await AuthService.getAvoUserInfoByEmail(ldapUser.mail);
 			if (existingUser) {
 				throw new InternalServerError(
 					'Failed to create user because an avo user with this email address already exists',
 					null,
 					{
 						existingUser,
-						newUser: user,
+						newUser: ldapUser,
 					});
 			}
-			const userUuid = await AuthController.createUser(user);
+			const userUuid = await AuthController.createUser(ldapUser);
 
 			// Create avo profile object
 			const profileId = await this.createProfile(ldapUserInfo, userUuid, stamboekNumber);
@@ -87,8 +88,18 @@ export default class HetArchiefController {
 			IdpHelper.setAvoUserInfoOnSession(req, userInfo);
 
 			// Add permission groups
-			// Users with a stamboek number are by default a "lesgever" and should be linked to that user group
-			await AuthService.addUserGroupsToProfile(2, profileId);
+			const userGroupIds = [];
+			if (stamboekNumber) {
+				userGroupIds.push(2);
+			}
+			if (ldapUser.roles && ldapUser.roles.length) {
+				// Link ldap user to groups
+				const userGroups: { id: number, label: string }[] = await AuthService.getUserGroupsByLdapRoleNames(ldapUser.roles);
+				userGroupIds.push(...userGroups.map(ug => ug.id));
+			}
+			if (userGroupIds.length) {
+				await AuthService.addUserGroupsToProfile(_.uniq(userGroupIds), profileId);
+			}
 
 			// Check if user is linked to hetarchief idp, if not create a link in the idp_map table
 			if (!(userInfo.idpmaps || []).includes('HETARCHIEF')) {
@@ -103,8 +114,10 @@ export default class HetArchiefController {
 						}
 					);
 				}
-				await IdpHelper.createIdpMap('SMARTSCHOOL', ldapUserInfo.attributes.entryUUID[0], userUuid);
+				await IdpHelper.createIdpMap('HETARCHIEF', ldapUserInfo.attributes.entryUUID[0], userUuid);
 			}
+
+			return AuthService.getAvoUserInfoById(userUuid);
 		} catch (err) {
 			throw new InternalServerError('Failed to create user and profile in the avo database', err, {
 				stamboekNumber,
@@ -131,13 +144,13 @@ export default class HetArchiefController {
 		return AuthController.createProfile(profile);
 	}
 
-	private static parseLdapObject(ldapObject: LdapUser): Partial<Avo.User.User> {
+	private static parseLdapObject(ldapObject: LdapUser): BasicIdpUserInfo {
 		return {
 			first_name: _.get(ldapObject, 'attributes.givenName[0]', ''),
 			last_name: _.get(ldapObject, 'attributes.sn[0]', ''),
 			mail: _.get(ldapObject, 'attributes.mail[0]', ''),
 			organisation_id: _.get(ldapObject, 'attributes.o[0]', ''),
-			role_id: LDAP_ROLE_TO_USER_ROLE[_.get(ldapObject, 'attributes.organizationalStatus')] || LDAP_ROLE_TO_USER_ROLE.User,
+			roles: _.get(ldapObject, 'attributes.organizationalStatus'),
 		};
 	}
 

--- a/server/src/modules/auth/idps/hetarchief/route.ts
+++ b/server/src/modules/auth/idps/hetarchief/route.ts
@@ -81,6 +81,13 @@ export default class HetArchiefRoute {
 						avoUser = await HetArchiefController.getAvoUserInfoFromDatabaseByEmail(ldapUser);
 						if (avoUser) {
 							await IdpHelper.createIdpMap('HETARCHIEF', ldapUser.attributes.entryUUID[0], String(avoUser.uid));
+						}	else if (!isPartOfRegistrationProcess) {
+							// No avo user exists yet and this call isn't part of a registration flow
+							// Check if ldap user has the avo group
+							if (ldapUser.attributes.apps.includes('avo')) {
+								// Create the avo user for this ldap account
+								avoUser = await HetArchiefController.createUserAndProfile(this.context.request, null);
+							}
 						}
 					}
 

--- a/server/src/modules/auth/idps/smartschool/controller.ts
+++ b/server/src/modules/auth/idps/smartschool/controller.ts
@@ -12,6 +12,7 @@ import AuthController from '../../controller';
 import { InternalServerError } from '../../../../shared/helpers/error';
 
 import SmartschoolService, { SmartschoolToken, SmartschoolUserInfo } from './service';
+import { BasicIdpUserInfo } from '../hetarchief/controller';
 
 export type SmartschoolLoginError = 'FIRST_LINK_ACCOUNT' | 'NO_ACCESS';
 export type LoginErrorResponse = { error: SmartschoolLoginError };
@@ -50,7 +51,7 @@ export default class SmartschoolController extends IdpHelper {
 				profileId = await this.createProfile(smartschoolUserInfo, userUid);
 
 				// Add permission groups
-				await AuthService.addUserGroupsToProfile(4, profileId);
+				await AuthService.addUserGroupsToProfile([4], profileId);
 			}
 
 			const avoUser: Avo.User.User = await AuthService.getAvoUserInfoById(userUid);
@@ -95,12 +96,12 @@ export default class SmartschoolController extends IdpHelper {
 
 	private static async createUser(smartschoolUserInfo: SmartschoolUserInfo): Promise<string> {
 		try {
-			const user: Partial<Avo.User.User> = {
+			const user: BasicIdpUserInfo = {
 				first_name: smartschoolUserInfo.voornaam,
 				last_name: smartschoolUserInfo.naam,
 				mail: smartschoolUserInfo.email,
 				organisation_id: smartschoolUserInfo.instellingsnummer ? String(smartschoolUserInfo.instellingsnummer) : null,
-				role_id: 4, // TODO switch this to a lookup in the database for role with name 'student'
+				roles: ['leerling'],
 			};
 			const userUid = await AuthController.createUser(user);
 

--- a/server/src/modules/auth/queries.gql.ts
+++ b/server/src/modules/auth/queries.gql.ts
@@ -124,7 +124,7 @@ query getUserInfoById($userId: uuid!) {
 
 export const GET_USER_BY_LDAP_UUID = `
 query getUserByLdapUuid($ldapUuid: String!) {
-  users_idp_map(where: {idp: {_eq: HETARCHIEF}, idp_user_id: {_eq: $ldapUuid}}) {
+  users_idp_map(where: {idp: {_eq: HETARCHIEF}, idp_user_id: {_eq: $ldapUuid}}, limit: 1) {
     local_user {
       id
       first_name

--- a/server/src/modules/auth/queries.gql.ts
+++ b/server/src/modules/auth/queries.gql.ts
@@ -245,9 +245,9 @@ query getProfileIdsByUserUid($userUid: uuid!) {
 }
 `;
 
-export const LINK_USER_GROUP_TO_PROFILE = `
-mutation linkUserGroupToProfile($userGroupId: Int!, $profileId: uuid!) {
-  insert_users_profile_user_groups(objects: {user_group_id: $userGroupId, user_profile_id: $profileId}) {
+export const LINK_USER_GROUPS_TO_PROFILE = `
+mutation linkUserGroupToProfile($objects: [users_profile_user_groups_insert_input!]!) {
+  insert_users_profile_user_groups(objects: $objects) {
     returning {
       id
     }
@@ -263,4 +263,21 @@ mutation unlinkUserGroupFromProfile($userGroupId: Int!, $profileId: uuid!) {
     }
   }
 }
+`;
+
+export const GET_USER_ROLE_BY_NAME = `
+	query getUserRoles($roleName: String!) {
+		shared_user_roles(where: {name: {_eq: $roleName}}) {
+			id
+		}
+	}
+`;
+
+export const GET_USER_GROUPS_BY_LDAP_ROLE_NAMES = `
+	query getUserGroupsByLdapRoleNames($roleNames: [String!]!) {
+		users_groups(where: {label: {_in: $roleNames}}) {
+			label
+			id
+		}
+	}
 `;

--- a/server/src/modules/profile/controller.ts
+++ b/server/src/modules/profile/controller.ts
@@ -66,7 +66,7 @@ export default class ProfileController {
 				!((profile as any).userGroupIds || []).includes(3)
 			) {
 				// Add "lesgever secundair" to this profile's usergroups
-				await AuthService.addUserGroupsToProfile(3, profile.id);
+				await AuthService.addUserGroupsToProfile([3], profile.id);
 			}
 			if (
 				!completeVars.educationLevels.find(edLevel => edLevel.key === 'Secundair onderwijs') &&


### PR DESCRIPTION
closes: https://district01.atlassian.net/browse/AVO2-943

Features:
* When a user tries to login using their archief account, and they have the avo app permission on their ldap account, we should create the corresponding avo user and profile.
* When creating a user set their appropriate user groups based on the ldap organizational status field

You can test this by logging in with one of the test accounts (in 1password) and seeing that you can login since those accounts do not have an avo user/profile yet (except for the eindredacteur test acount)