### PR TITLE
feat(organizations): add token to org api requests

### DIFF
--- a/server/src/modules/organization/service.ts
+++ b/server/src/modules/organization/service.ts
@@ -1,5 +1,4 @@
 import axios, { AxiosResponse } from 'axios';
-import { find } from 'lodash';
 import cron from 'node-cron';
 
 import { logger, logIfNotTestEnv } from '../../shared/helpers/logger';
@@ -75,6 +74,9 @@ export default class OrganizationService {
 			const orgResponse: AxiosResponse<OrganizationResponse> = await axios({
 				url,
 				method: 'get',
+				headers: {
+					authorization: `bearer ${process.env.ORGANIZATIONS_API_TOKEN}`,
+				},
 			});
 
 			// Handle response


### PR DESCRIPTION
closes: https://meemoo.atlassian.net/browse/AVO-224

The  ORGANIZATIONS_API_TOKEN has been added to all environment variables
This value will have to be filled in by tina or herwig in openshift

They should only enable authentication once this PR has been deployed to QAS and PRD