### PR TITLE
fix(search): remove escape function from elasticsearch search term

### DIFF
--- a/server/src/modules/search/queryBuilder.ts
+++ b/server/src/modules/search/queryBuilder.ts
@@ -11,7 +11,6 @@ import {
 import { InternalServerError } from '../../shared/helpers/error';
 import { logger } from '../../shared/helpers/logger';
 
-const escapeElastic = require('elasticsearch-sanitize');
 const removeAccents = require('remove-accents');
 
 const textQueryObjectTemplate = _.values(textQueryObjectTemplateImport);
@@ -128,7 +127,7 @@ export default class QueryBuilder {
 		if (stringQuery) {
 			// Replace {{query}} in the template with the escaped search terms
 			const textQueryObjectArray = _.cloneDeep(textQueryObjectTemplate);
-			const escapedQueryString = escapeElastic(stringQuery); // Avoid elasticsearch injection attacks
+			const escapedQueryString = stringQuery;
 			_.forEach(textQueryObjectArray, (matchObj) => {
 				_.set(matchObj, 'multi_match.query', escapedQueryString);
 			});


### PR DESCRIPTION
closes: https://meemoo.atlassian.net/browse/AVO-225

It's not a problem for people to be able to add wildcards into a search query. Escaping characters seems to cause issues with the search results not matching the expected results.