### PR TITLE
fix(idp-map): avoid throwing error when idp map already exists

### DIFF
--- a/server/src/modules/auth/idp-helper.ts
+++ b/server/src/modules/auth/idp-helper.ts
@@ -111,11 +111,13 @@ export class IdpHelper {
 				);
 			}
 		} catch (err) {
-			throw new CustomError(
-				'Failed to link user to idp',
-				err,
-				{ idp, idpUserId, localUserId, query: INSERT_PROFILE }
-			);
+			if (!JSON.stringify(err).includes('constraint-violation')) { // idp map already exists
+				throw new CustomError(
+					'Failed to link user to idp',
+					err,
+					{ idp, idpUserId, localUserId, query: INSERT_PROFILE }
+				);
+			}
 		}
 	}
 

--- a/server/src/modules/auth/queries.gql.ts
+++ b/server/src/modules/auth/queries.gql.ts
@@ -206,6 +206,14 @@ export const INSERT_PROFILE = `
 	}
 `;
 
+export const GET_IDP_MAP = `
+	query insertIdp($idpType: users_idps_enum!, $idpUserId: String!, $localUserId: uuid!) {
+		users_idp_map(where: {idp_user_id: {_eq: $idpUserId}, local_user_id: {_eq: $localUserId}, idp: {_eq: $idpType}}) {
+			id
+		}
+	}
+`;
+
 /**
  * Link a user to a specific idp id
  * Eg: user links their account to smartschool


### PR DESCRIPTION
otherwise you can't login with the test accounts, eg:
accounts+eindredacteur@meemoo.be