### PR TITLE
fix(auth): add fallback for redirect to params in login routes

### DIFF
--- a/server/src/modules/auth/idps/hetarchief/route.ts
+++ b/server/src/modules/auth/idps/hetarchief/route.ts
@@ -40,10 +40,11 @@ export default class HetArchiefRoute {
 	@GET
 	async login(@QueryParam('returnToUrl') returnToUrl: string): Promise<any> {
 		try {
+			const returnTo = returnToUrl || `${process.env.CLIENT_HOST}/home`;
 			if (AuthController.isAuthenticated(this.context.request)) {
-				return new Return.MovedTemporarily<void>(returnToUrl);
+				return new Return.MovedTemporarily<void>(returnTo);
 			}
-			const url = await HetArchiefService.createLoginRequestUrl(returnToUrl);
+			const url = await HetArchiefService.createLoginRequestUrl(returnTo);
 			return new Return.MovedTemporarily<void>(url);
 		} catch (err) {
 			const error = new InternalServerError('Failed during auth login route', err, {});

--- a/server/src/modules/auth/idps/klascement/route.ts
+++ b/server/src/modules/auth/idps/klascement/route.ts
@@ -26,7 +26,7 @@ export default class KlascementRoute {
 	async login(@QueryParam('returnToUrl') returnToUrl: string): Promise<any> {
 		try {
 			const requestId = getUuid();
-			_.set(this.context, REDIRECT_URL_PATH, returnToUrl);
+			_.set(this.context, REDIRECT_URL_PATH, (returnToUrl || `${process.env.CLIENT_HOST}/home`));
 			_.set(this.context, REQUEST_ID_PATH, requestId);
 			const url = KlascementService.getRedirectUrlForCode(requestId);
 			return new Return.MovedTemporarily<void>(url);

--- a/server/src/modules/auth/idps/smartschool/route.ts
+++ b/server/src/modules/auth/idps/smartschool/route.ts
@@ -28,7 +28,7 @@ export default class SmartschoolRoute {
 	@GET
 	async login(@QueryParam('returnToUrl') returnToUrl: string): Promise<any> {
 		try {
-			_.set(this.context, REDIRECT_URL_PATH, returnToUrl);
+			_.set(this.context, REDIRECT_URL_PATH, (returnToUrl || `${process.env.CLIENT_HOST}/home`));
 			const url = SmartschoolService.getRedirectUrlForCode();
 			return new Return.MovedTemporarily<void>(url);
 		} catch (err) {


### PR DESCRIPTION
part of https://district01.atlassian.net/browse/AVO2-1048

client twin: https://github.com/viaacode/avo2-client/pull/525

This way users can point to {{PROXY_URL}}/auth/smartschool/login without having to provide the ?redirectToUrl query param