### PR TITLE
fix(campaign-monitor): change custom fields to comma separated strings

### DIFF
--- a/server/src/modules/campaign-monitor/controller.ts
+++ b/server/src/modules/campaign-monitor/controller.ts
@@ -54,7 +54,6 @@ export default class CampaignMonitorController {
 			const lastName = _.get(user, 'last_name');
 			const name = [firstName, lastName].join(' ').trim();
 
-			const userRole = _.get(user, 'role.label');
 			const userGroupId = _.get(user, 'profile.userGroupIds[0]');
 			const allUserGroups = await AuthService.getAllUserGroups();
 			const userGroup = _.get(
@@ -102,7 +101,6 @@ export default class CampaignMonitorController {
 						name,
 						{
 							oormerk,
-							gebruikersrol: userRole,
 							gebruikersgroep: userGroup,
 							stamboeknummer: stamboekNumber,
 							is_uitzondering: isExceptionAccount ? 'true' : 'false',

--- a/server/src/modules/campaign-monitor/controller.ts
+++ b/server/src/modules/campaign-monitor/controller.ts
@@ -9,10 +9,14 @@ import EducationOrganizationsService from '../education-organizations/service';
 
 import { NEWSLETTER_LISTS } from './const';
 import CampaignMonitorService from './service';
-import { CustomFields, EmailInfo, NewsletterKey, NewsletterPreferences } from './types';
+import {
+	CustomFields,
+	EmailInfo,
+	NewsletterKey,
+	NewsletterPreferences,
+} from './types';
 
 export default class CampaignMonitorController {
-
 	/**
 	 * Send an email using the campaign monitor api
 	 * @param info
@@ -34,9 +38,15 @@ export default class CampaignMonitorController {
 	 * @param user
 	 * @param preferences
 	 */
-	public static async updateNewsletterPreferences(user: Avo.User.User, preferences: Partial<NewsletterPreferences>) {
+	public static async updateNewsletterPreferences(
+		user: Avo.User.User,
+		preferences: Partial<NewsletterPreferences>
+	) {
 		try {
-			const mappedPreferences = _.toPairs(preferences) as [NewsletterKey, boolean][];
+			const mappedPreferences = _.toPairs(preferences) as [
+				NewsletterKey,
+				boolean
+			][];
 
 			const email = _.get(user, 'mail');
 
@@ -44,26 +54,39 @@ export default class CampaignMonitorController {
 			const lastName = _.get(user, 'last_name');
 			const name = [firstName, lastName].join(' ').trim();
 
+			const userRole = _.get(user, 'role.label');
 			const userGroupId = _.get(user, 'profile.userGroupIds[0]');
 			const allUserGroups = await AuthService.getAllUserGroups();
-			const userGroup = _.get(allUserGroups.find(group => group.id === userGroupId), 'label');
+			const userGroup = _.get(
+				allUserGroups.find(group => group.id === userGroupId),
+				'label'
+			);
 
 			const oormerk = _.get(user, 'oormerk'); // Wait for https://meemoo.atlassian.net/browse/DEV-949
+			const isExceptionAccount = _.get(user, 'is_exception');
 			const stamboekNumber = _.get(user, 'profile.stamboek');
-			const educationLevel = _.get(user, 'profile.educationLevels[0]');
+			const educationLevels: string[] = _.get(user, 'profile.educationLevels');
 
-			let school: string;
-			const educationalOrganizationId = _.get(user, 'profile.organizations[0].organization_id');
-			const educationalOrganizationUnitId = _.get(user, 'profile.organizations[0].unit_id');
-			if (educationalOrganizationId) {
-				// Waiting for https://meemoo.atlassian.net/browse/AVO-939
-				const educationalOrganization = await EducationOrganizationsService.getOrganization(educationalOrganizationId, educationalOrganizationUnitId);
-				school = [
-					educationalOrganization.city,
-					educationalOrganization.name,
-					educationalOrganization.units.find(unit => unit.id === educationalOrganizationUnitId),
-				].join('___');
-			}
+			const schoolZipcodes: string[] = [];
+			const schoolIds: string[] = [];
+			const campusIds: string[] = [];
+			const schoolNames: string[] = [];
+			const educationalOrganizations: Avo.EducationOrganization.Organization[] = _.get(user, 'profile.organizations') || [];
+			await promiseUtils.map(educationalOrganizations, async (org) => {
+				const educationalOrganizationId = _.get(org, 'organizationId');
+				const educationalOrganizationUnitId = _.get(org, 'unitId');
+				if (educationalOrganizationId) {
+					// Waiting for https://meemoo.atlassian.net/browse/AVO-939
+					const educationalOrganization = await EducationOrganizationsService.getOrganization(
+						educationalOrganizationId,
+						educationalOrganizationUnitId
+					);
+					schoolZipcodes.push(educationalOrganization.postal_code);
+					schoolNames.push(educationalOrganization.name);
+					schoolIds.push(educationalOrganizationId);
+					campusIds.push(educationalOrganizationUnitId);
+				}
+			});
 
 			const subjects = _.get(user, 'profile.subjects', []).join(', ');
 
@@ -72,18 +95,40 @@ export default class CampaignMonitorController {
 				const subscribed = preference[1];
 
 				if (subscribed) {
-					await CampaignMonitorService.subscribeToNewsletterList(NEWSLETTER_LISTS[key], email, name, {
-						Graad: educationLevel,
-						Lerarenkaart: stamboekNumber,
-						Role: oormerk,
-						School: school,
-					} as CustomFields);
+					const join = (arr: (string | undefined | null)[]) => _.uniq(_.compact(arr)).join(', ');
+					await CampaignMonitorService.subscribeToNewsletterList(
+						NEWSLETTER_LISTS[key],
+						email,
+						name,
+						{
+							oormerk,
+							gebruikersrol: userRole,
+							gebruikersgroep: userGroup,
+							stamboeknummer: stamboekNumber,
+							is_uitzondering: isExceptionAccount ? 'true' : 'false',
+							firstname: firstName,
+							lastname: lastName,
+							graad: join(educationLevels),
+							vakken: subjects,
+							school_postcodes: join(schoolZipcodes),
+							school_ids: join(schoolIds),
+							school_campus_ids: join(campusIds),
+							school_namen: join(schoolNames),
+						} as CustomFields
+					);
 				} else {
-					await CampaignMonitorService.unsubscribeFromNewsletterList(NEWSLETTER_LISTS[key], email);
+					await CampaignMonitorService.unsubscribeFromNewsletterList(
+						NEWSLETTER_LISTS[key],
+						email
+					);
 				}
 			});
 		} catch (err) {
-			throw new InternalServerError('Failed to update newsletter preferences', err, { user, preferences });
+			throw new InternalServerError(
+				'Failed to update newsletter preferences',
+				err,
+				{ user, preferences }
+			);
 		}
 	}
 }

--- a/server/src/modules/campaign-monitor/route.ts
+++ b/server/src/modules/campaign-monitor/route.ts
@@ -8,6 +8,8 @@ import { IdpHelper } from '../auth/idp-helper';
 import { templateIds } from './const';
 import CampaignMonitorController from './controller';
 import { EmailInfo } from './types';
+import HetArchiefService from '../auth/idps/hetarchief/service';
+import { AuthService } from '../auth/service';
 
 @Path('/campaign-monitor')
 export default class CampaignMonitorRoute {
@@ -80,7 +82,9 @@ export default class CampaignMonitorRoute {
 		body: any
 	) {
 		try {
-			return await CampaignMonitorController.updateNewsletterPreferences(IdpHelper.getAvoUserInfoFromSession(this.context.request), body.preferences);
+			let avoUser = IdpHelper.getAvoUserInfoFromSession(this.context.request);
+			avoUser = await AuthService.getAvoUserInfoById(avoUser.uid);
+			return await CampaignMonitorController.updateNewsletterPreferences(avoUser, body.preferences);
 		} catch (err) {
 			const error = new InternalServerError('Failed during update in campaign monitor preferences route', err, { email: body.email });
 			logger.error(error);

--- a/server/src/modules/campaign-monitor/types.ts
+++ b/server/src/modules/campaign-monitor/types.ts
@@ -9,11 +9,19 @@ export interface NewsletterPreferences {
 }
 
 export interface CustomFields {
-	Role: string;
-	Lerarenkaart: string;
-	Graad: string;
-	School: string;
-	Vestigingsnummer: string;
+	gebruikersrol: string;
+	gebruikersgroep: string;
+	oormerk: string;
+	stamboeknummer: string;
+	is_uitzondering: string;
+	firstname: string;
+	lastname: string;
+	graad: string;
+	vakken: string;
+	school_postcodes: string;
+	school_ids: string;
+	school_campus_ids: string;
+	school_namen: string;
 }
 
 export type NewsletterKey = keyof NewsletterPreferences;

--- a/server/src/modules/campaign-monitor/types.ts
+++ b/server/src/modules/campaign-monitor/types.ts
@@ -9,7 +9,6 @@ export interface NewsletterPreferences {
 }
 
 export interface CustomFields {
-	gebruikersrol: string;
 	gebruikersgroep: string;
 	oormerk: string;
 	stamboeknummer: string;


### PR DESCRIPTION
closes: https://meemoo.atlassian.net/browse/AVO-939

custom fields sent to campaign monitor should be:
```
{
  "gebruikersrol": "Lesgever",
  "gebruikersgroep": "Lesgever secundair",
  "stamboeknummer": null,
  "is_uitzondering": "false",
  "firstname": "Lesgever",
  "lastname": "Account",
  "graad": "Secundair onderwijs, Lager onderwijs",
  "vakken": "lichamelijke opvoeding, muzische vorming",
  "school_postcodes": "2970, 9300, 8511, 8870",
  "school_ids": "100065, 104851, 18788, 19497, 8284",
  "school_campus_ids": "104851-2-111, 18788-1-111, 19497-1-111, 8284-1-111",
  "school_namen": "GO! internaat medisch pedagogisch instituut Zonnebos 's Gravenwezel, Vrije Basisschool - DvM, Vrije Basisschool, Vrije Basisschool - Heilig-Hart"
}
```