### PR TITLE
fix(content-pages): resolve manual tiles as well, set audio still

### DIFF
--- a/server/src/modules/content-pages/consts.ts
+++ b/server/src/modules/content-pages/consts.ts
@@ -20,3 +20,5 @@ export const MEDIA_PLAYER_BLOCKS: { [blockType: string]: MediaPlayerPathInfo } =
 		setOrganisationPath: 'variables.componentState.mediaOrganisation',
 	},
 };
+
+export const DEFAULT_AUDIO_STILL = '/images/audio-still.svg';

--- a/server/src/modules/content-pages/queries.gql.ts
+++ b/server/src/modules/content-pages/queries.gql.ts
@@ -54,8 +54,15 @@ export const GET_ITEM_TILE_BY_ID = `
 		obj: app_item_meta(where: { external_id: { _eq: $id } }) {
 			created_at
 			duration
+			browse_path
 			thumbnail_path
 			title
+			description
+			issued
+			organisation {
+				name
+				logo_url
+			}
 			type {
 				label
 				id
@@ -82,6 +89,9 @@ export const GET_ITEM_BY_EXTERNAL_ID = `
 			organisation {
 				name
 				logo_url
+			}
+			type {
+				label
 			}
 		}
 	}

--- a/server/src/modules/content-pages/service.ts
+++ b/server/src/modules/content-pages/service.ts
@@ -42,7 +42,10 @@ export default class ContentPageService {
 			);
 
 			const itemOrCollection = _.get(response, 'data.obj[0]', null);
-			// const count = _.get(response, 'data.count[0]', 0); // TODO fix counts
+			if (itemOrCollection) {
+				itemOrCollection.count =
+					_.get(response, 'data.view_counts_aggregate.aggregate.sum.count') || 0;
+			}
 
 			return itemOrCollection;
 		} catch (err) {


### PR DESCRIPTION
closes:
* AVO-969
* AVO-372

test pages:
* media tile manual selected audio item: http://localhost:8080/media-tegels-in-modal-test
* media player selected mam audio item: http://localhost:8080/audio-on-logged-out-content-page

![image](https://user-images.githubusercontent.com/1710840/85843681-cde25000-b7a1-11ea-8645-232bf0318ccf.png)

![image](https://user-images.githubusercontent.com/1710840/85843631-b99e5300-b7a1-11ea-95bd-35d35327487e.png)

![image](https://user-images.githubusercontent.com/1710840/85843621-b4d99f00-b7a1-11ea-8f40-4723be8faee5.png)
