### PR TITLE
fix(hetarchief-route): remove check on is_blocked

### DIFF
--- a/server/src/modules/auth/idps/hetarchief/route.ts
+++ b/server/src/modules/auth/idps/hetarchief/route.ts
@@ -131,14 +131,6 @@ export default class HetArchiefRoute {
 					);
 				}
 
-				if (get(avoUser, 'is_blocked')) {
-					return redirectToClientErrorPage(
-						i18n.t('modules/auth/idps/hetarchief/route___geen-avo-groep-error'),
-						'lock',
-						['home', 'helpdesk']
-					);
-				}
-
 				IdpHelper.setAvoUserInfoOnSession(this.context.request, avoUser);
 			} catch (err) {
 				if (JSON.stringify(err).includes('ENOTFOUND')) {


### PR DESCRIPTION
since we already check the ldap object for the avo app and users with an ldap account do not use the is_blocked status