### PR TITLE
fix(collections-controller): safely get permissions from profile

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "avo2-proxy-server",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "avo2-proxy-server",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "description": "Deze repo bevat de NodeJS service die de communicatie regelt tussen de Archief voor Onderwijs frontend applicaties enerzijds en de backend services anderzijds.",
   "main": "index.ts",
   "repository": {

--- a/server/src/modules/collections/collections.controller.ts
+++ b/server/src/modules/collections/collections.controller.ts
@@ -23,6 +23,7 @@ export default class CollectionsController {
 		const isLinkedToAssignment = isNil(assignmentId)
 			? false
 			: await CollectionsService.isCollectionLinkedToAssignment(id, assignmentId);
+		const permissions: string[] = get(avoUser, 'profile.permissions') || [];
 		const { is_public } = collection;
 
 		// Return the collection/bundle if:
@@ -36,23 +37,14 @@ export default class CollectionsController {
 			isOwner ||
 			isLinkedToAssignment ||
 			(type === 'bundle' &&
-				((is_public &&
-					avoUser.profile.permissions.includes(
-						PermissionName.VIEW_ANY_PUBLISHED_BUNDLES
-					)) ||
+				((is_public && permissions.includes(PermissionName.VIEW_ANY_PUBLISHED_BUNDLES)) ||
 					(!is_public &&
-						avoUser.profile.permissions.includes(
-							PermissionName.VIEW_ANY_UNPUBLISHED_BUNDLES
-						)))) ||
+						permissions.includes(PermissionName.VIEW_ANY_UNPUBLISHED_BUNDLES)))) ||
 			(type === 'collection' &&
 				((is_public &&
-					avoUser.profile.permissions.includes(
-						PermissionName.VIEW_ANY_PUBLISHED_COLLECTIONS
-					)) ||
+					permissions.includes(PermissionName.VIEW_ANY_PUBLISHED_COLLECTIONS)) ||
 					(!is_public &&
-						avoUser.profile.permissions.includes(
-							PermissionName.VIEW_ANY_UNPUBLISHED_COLLECTIONS
-						))))
+						permissions.includes(PermissionName.VIEW_ANY_UNPUBLISHED_COLLECTIONS))))
 		) {
 			return collection;
 		}


### PR DESCRIPTION
closes: https://meemoo.atlassian.net/browse/AVO-1243

example private bundle: http://localhost:8080/bundels/0edd4e40-5957-435d-9e54-039261553167

before this fix, fetching a private collection without being loggged in would give you this error:
![image](https://user-images.githubusercontent.com/1710840/89289596-cd1dc300-d657-11ea-81b8-11f793ff328a.png)

After the fix:
![image](https://user-images.githubusercontent.com/1710840/89289697-f6d6ea00-d657-11ea-8855-686f4bca7c81.png)
