### PR TITLE
fix(auth-het-archief-route): redirect to error when no role from ldap

### DIFF
--- a/server/src/modules/auth/idps/hetarchief/route.ts
+++ b/server/src/modules/auth/idps/hetarchief/route.ts
@@ -144,7 +144,8 @@ export default class HetArchiefRoute {
 
 				IdpHelper.setAvoUserInfoOnSession(this.context.request, avoUser);
 			} catch (err) {
-				if (JSON.stringify(err).includes('ENOTFOUND')) {
+				const errorString = JSON.stringify(err);
+				if (errorString.includes('ENOTFOUND')) {
 					// Failed to connect to the database
 					return redirectToClientErrorPage(
 						i18n.t(
@@ -154,6 +155,18 @@ export default class HetArchiefRoute {
 						['home', 'helpdesk']
 					);
 				}
+
+				if (errorString.includes('Failed to get role id by role name from the database')) {
+					// User does not have a usergroup in LDAP
+					return redirectToClientErrorPage(
+						i18n.t(
+							'Je account heeft nog geen gebruikersgroep. Gelieve de helpdesk te contacteren.'
+						),
+						'alert-triangle',
+						['home', 'helpdesk']
+					);
+				}
+
 				// We want to use this route also for registration, so it could be that the avo user and profile do not exist yet
 				logger.info(
 					'login callback without avo user object found (this is correct for the registration flow)',


### PR DESCRIPTION
closes: https://meemoo.atlassian.net/browse/AVO-1283

![image](https://user-images.githubusercontent.com/1710840/90235837-3b197580-de22-11ea-843d-c02d78f3bd0a.png)

before: login loop:
![image](https://user-images.githubusercontent.com/1710840/90235853-42d91a00-de22-11ea-8a34-db21e7461e6b.png)

after: clear error message:
![image](https://user-images.githubusercontent.com/1710840/90235878-4a98be80-de22-11ea-9f70-3e5783ec722f.png)
