### PR TITLE
feat(content-pages): return counts of pages for each label

### DIFF
--- a/server/src/modules/content-pages/controller.ts
+++ b/server/src/modules/content-pages/controller.ts
@@ -14,7 +14,7 @@ import PlayerTicketRoute from '../player-ticket/route';
 
 import { DEFAULT_AUDIO_STILL, MEDIA_PLAYER_BLOCKS } from './consts';
 import ContentPageService from './service';
-import { ResolvedItemOrCollection } from './types';
+import { ContentPageOverviewResponse, ResolvedItemOrCollection } from './types';
 
 export type MediaItemResponse = Partial<Avo.Collection.Collection | Avo.Item.Item> & {
 	count: number;
@@ -86,17 +86,19 @@ export default class ContentPageController {
 		withBlock: boolean,
 		contentType: string,
 		labelIds: number[],
+		selectedLabelIds: number[],
 		orderByProp: string,
 		orderByDirection: 'asc' | 'desc',
 		offset: number,
 		limit: number,
 		user: Avo.User.User
-	): Promise<{ pages: Avo.ContentPage.Page[]; count: number }> {
+	): Promise<ContentPageOverviewResponse> {
 		return ContentPageService.fetchContentPages(
 			withBlock,
 			getUserGroupIds(user),
 			contentType,
 			labelIds,
+			selectedLabelIds,
 			orderByProp,
 			orderByDirection,
 			offset,

--- a/server/src/modules/content-pages/queries.gql.ts
+++ b/server/src/modules/content-pages/queries.gql.ts
@@ -131,7 +131,9 @@ export const GET_CONTENT_PAGES_WITH_BLOCKS = `
 		$where: app_content_bool_exp
 		$offset: Int = 0
 		$limit: Int = 10
-		$orderBy: [app_content_order_by!] = {}
+		$orderBy: [app_content_order_by!] = {},
+		$labelIds: [Int!] = [],
+		$orUserGroupIds: [app_content_content_labels_bool_exp] = {}
 	) {
 		app_content(where: $where, limit: $limit, offset: $offset, order_by: $orderBy) {
 			content_type
@@ -184,15 +186,25 @@ export const GET_CONTENT_PAGES_WITH_BLOCKS = `
 				count
 			}
 		}
+		app_content_labels(where: {id: {_in: $labelIds}}) {
+			id
+			content_content_labels_aggregate(where: {_or: $orUserGroupIds}) {
+				aggregate {
+					count
+				}
+			}
+		}
 	}
 `;
 
 export const GET_CONTENT_PAGES = `
 	query getContentPages(
-		$where: app_content_bool_exp
-		$offset: Int = 0
-		$limit: Int = 10
-		$orderBy: [app_content_order_by!] = {}
+		$where: app_content_bool_exp,
+		$offset: Int = 0,
+		$limit: Int = 10,
+		$orderBy: [app_content_order_by!] = {},
+		$labelIds: [Int!] = [],
+		$orUserGroupIds: [app_content_content_labels_bool_exp] = {}
 	) {
 		app_content(where: $where, limit: $limit, offset: $offset, order_by: $orderBy) {
 			content_type
@@ -232,6 +244,14 @@ export const GET_CONTENT_PAGES = `
 		app_content_aggregate(where: $where) {
 			aggregate {
 				count
+			}
+		}
+		app_content_labels(where: {id: {_in: $labelIds}}) {
+			id
+			content_content_labels_aggregate(where: {_or: $orUserGroupIds}) {
+				aggregate {
+					count
+				}
 			}
 		}
 	}

--- a/server/src/modules/content-pages/route.ts
+++ b/server/src/modules/content-pages/route.ts
@@ -16,7 +16,7 @@ import { isAuthenticatedRouteGuard } from '../../shared/middleware/is-authentica
 import { IdpHelper } from '../auth/idp-helper';
 
 import ContentPageController from './controller';
-import { ContentPageOverviewParams } from './types';
+import { ContentPageOverviewParams, ContentPageOverviewResponse } from './types';
 
 @Path('/content-pages')
 export default class ContentPagesRoute {
@@ -54,12 +54,13 @@ export default class ContentPagesRoute {
 	@POST
 	async getContentPagesForOverview(
 		body: ContentPageOverviewParams
-	): Promise<{ pages: Avo.ContentPage.Page[]; count: number }> {
+	): Promise<ContentPageOverviewResponse> {
 		try {
 			return ContentPageController.getContentPagesForOverview(
 				body.withBlock,
 				body.contentType,
 				body.labelIds,
+				body.selectedLabelIds,
 				body.orderByProp || 'published_at',
 				body.orderByDirection || 'desc',
 				body.offset,
@@ -87,11 +88,11 @@ export default class ContentPagesRoute {
 		searchQueryLimit: string | undefined;
 		mediaItems:
 			| {
-					mediaItem: {
-						type: 'ITEM' | 'COLLECTION' | 'BUNDLE';
-						value: string;
-					};
-			  }[]
+			mediaItem: {
+				type: 'ITEM' | 'COLLECTION' | 'BUNDLE';
+				value: string;
+			};
+		}[]
 			| undefined;
 	}): Promise<any[]> {
 		try {

--- a/server/src/modules/content-pages/types.ts
+++ b/server/src/modules/content-pages/types.ts
@@ -17,9 +17,18 @@ export type ResolvedItemOrCollection = Partial<Avo.Item.Item | Avo.Collection.Co
 export interface ContentPageOverviewParams {
 	withBlock: boolean;
 	contentType: string;
+	// Visible tabs in the page overview component for which we should fetch item counts
 	labelIds: number[];
+	// Selected tabs for which we should fetch content page items
+	selectedLabelIds: number[];
 	orderByProp?: string;
 	orderByDirection?: 'asc' | 'desc';
 	offset: number;
 	limit: number;
+}
+
+export interface ContentPageOverviewResponse {
+	pages: Avo.ContentPage.Page[];
+	count: number;
+	labelCounts: { [id: number]: number };
 }


### PR DESCRIPTION
part of: https://meemoo.atlassian.net/browse/AVO-356

add counts for each label in overview endpoint:

```json
"app_content_labels": [
      {
        "label": "Lesgevers",
        "content_content_labels_aggregate": {
          "aggregate": {
            "count": 3
          }
        }
      },
      {
        "label": "Leerlingen",
        "content_content_labels_aggregate": {
          "aggregate": {
            "count": 0
          }
        }
      }
    ]
```
