### PR TITLE
feat(content-pages): add route to update published_at dates

### DIFF
--- a/server/src/modules/auth/route.ts
+++ b/server/src/modules/auth/route.ts
@@ -162,6 +162,7 @@ export default class AuthRoute {
 	async clearSessions(): Promise<any> {
 		try {
 			await clearRedis();
+			return { message: 'User sessions have been cleared' };
 		} catch (err) {
 			logger.error(new CustomError('Failed to clear redis sessions', err));
 		}

--- a/server/src/modules/content-pages/controller.ts
+++ b/server/src/modules/content-pages/controller.ts
@@ -8,6 +8,7 @@ import { SearchResultItem } from '@viaa/avo2-types/types/search/index';
 import { CustomError, ExternalServerError } from '../../shared/helpers/error';
 import { logger } from '../../shared/helpers/logger';
 import { getUserGroupIds } from '../auth/helpers/get-user-group-ids';
+import DataService from '../data/service';
 import OrganisationService from '../organization/service';
 import PlayerTicketController from '../player-ticket/controller';
 import PlayerTicketRoute from '../player-ticket/route';
@@ -225,11 +226,11 @@ export default class ContentPageController {
 		searchQueryLimit: string | undefined,
 		mediaItems:
 			| {
-					mediaItem: {
-						type: 'ITEM' | 'COLLECTION' | 'BUNDLE';
-						value: string;
-					};
-			  }[]
+			mediaItem: {
+				type: 'ITEM' | 'COLLECTION' | 'BUNDLE';
+				value: string;
+			};
+		}[]
 			| undefined,
 		request: Request
 	): Promise<Partial<Avo.Item.Item | Avo.Collection.Collection>[]> {
@@ -452,5 +453,9 @@ export default class ContentPageController {
 			);
 			return null;
 		}
+	}
+
+	static async updatePublishDates() {
+		return ContentPageService.updatePublishDates();
 	}
 }

--- a/server/src/modules/content-pages/queries.gql.ts
+++ b/server/src/modules/content-pages/queries.gql.ts
@@ -267,3 +267,30 @@ export const GET_PUBLIC_CONTENT_PAGES = `
 		}
 	}
 `;
+
+export const UPDATE_CONTENT_PAGE_PUBLISH_DATES = `
+  mutation publishContentPages($now: timestamptz, $publishedAt: timestamptz) {
+    publish_content_pages: update_app_content(
+      where: {
+        _or: [
+          {publish_at: {_lte: $now, _is_null: false}, depublish_at: {_gte: $now, _is_null: false}},
+          {publish_at: {_lte: $now, _is_null: false}, depublish_at: {_is_null: true}},
+          {publish_at: {_is_null: true}, published_at: {_gte: $now, _is_null: false}}
+        ],
+        published_at: {_is_null: true}
+      },
+      _set: {published_at: $publishedAt}
+    ) {
+      affected_rows
+    }
+    unpublish_content_pages: update_app_content(
+      where: {
+        depublish_at: {_lt: $now, _is_null: false},
+        published_at: {_is_null: false}
+      },
+      _set: {published_at: null}
+    ) {
+      affected_rows
+    }
+  }
+`;

--- a/server/src/modules/content-pages/route.ts
+++ b/server/src/modules/content-pages/route.ts
@@ -10,9 +10,17 @@ import {
 
 import { Avo } from '@viaa/avo2-types';
 
-import { InternalServerError, NotFoundError, UnauthorizedError } from '../../shared/helpers/error';
+import {
+	CustomError,
+	InternalServerError,
+	NotFoundError,
+	UnauthorizedError,
+} from '../../shared/helpers/error';
 import { logger } from '../../shared/helpers/logger';
-import { isAuthenticatedRouteGuard } from '../../shared/middleware/is-authenticated';
+import {
+	checkApiKeyRouteGuard,
+	isAuthenticatedRouteGuard,
+} from '../../shared/middleware/is-authenticated';
 import { IdpHelper } from '../auth/idp-helper';
 
 import ContentPageController from './controller';
@@ -88,11 +96,11 @@ export default class ContentPagesRoute {
 		searchQueryLimit: string | undefined;
 		mediaItems:
 			| {
-			mediaItem: {
-				type: 'ITEM' | 'COLLECTION' | 'BUNDLE';
-				value: string;
-			};
-		}[]
+					mediaItem: {
+						type: 'ITEM' | 'COLLECTION' | 'BUNDLE';
+						value: string;
+					};
+			  }[]
 			| undefined;
 	}): Promise<any[]> {
 		try {
@@ -114,6 +122,22 @@ export default class ContentPagesRoute {
 				err,
 				{ body }
 			);
+		}
+	}
+
+	@Path('update-published-dates')
+	@POST
+	@PreProcessor(checkApiKeyRouteGuard)
+	async updatePublishDates(): Promise<any> {
+		try {
+			const response = await ContentPageController.updatePublishDates();
+			return {
+				message: `content page publish dates have been updated, ${response.published} published, ${response.unpublished} unpublished`,
+			};
+		} catch (err) {
+			const error = new CustomError('Failed to update content page publish dates', err);
+			logger.error(error);
+			throw new InternalServerError(error.message);
 		}
 	}
 }

--- a/server/src/modules/content-pages/service.ts
+++ b/server/src/modules/content-pages/service.ts
@@ -1,9 +1,9 @@
 import { fromPairs, get } from 'lodash';
+import moment from 'moment';
 
 import { Avo } from '@viaa/avo2-types';
 
 import { CustomError, ExternalServerError, InternalServerError } from '../../shared/helpers/error';
-import { AuthService } from '../auth/service';
 import { SpecialPermissionGroups } from '../auth/types';
 import DataService from '../data/service';
 import SearchController from '../search/controller';
@@ -17,6 +17,7 @@ import {
 	GET_ITEM_BY_EXTERNAL_ID,
 	GET_ITEM_TILE_BY_ID,
 	GET_PUBLIC_CONTENT_PAGES,
+	UPDATE_CONTENT_PAGE_PUBLISH_DATES,
 } from './queries.gql';
 import { ContentPageOverviewResponse } from './types';
 
@@ -207,6 +208,27 @@ export default class ContentPageService {
 			return get(response, 'data.app_content') || [];
 		} catch (err) {
 			throw new InternalServerError('Failed to fetch all public content pages');
+		}
+	}
+
+	static async updatePublishDates(): Promise<{ published: number; unpublished: number }> {
+		try {
+			const response = await DataService.execute(UPDATE_CONTENT_PAGE_PUBLISH_DATES, {
+				now: new Date().toISOString(),
+				publishedAt: moment()
+					.hours(7)
+					.minutes(0)
+					.toISOString(),
+			});
+			if (response.errors) {
+				throw new InternalServerError('Graphql mutation returned errors', response);
+			}
+			return {
+				published: get(response, 'data.publish_content_pages.affected_rows', 0),
+				unpublished: get(response, 'data.unpublish_content_pages.affected_rows', 0),
+			};
+		} catch (err) {
+			throw new InternalServerError('Failed to update content page publish dates', err);
 		}
 	}
 }


### PR DESCRIPTION
closes: https://meemoo.atlassian.net/browse/AVO-1095

```
/content-pages/update-published-dates
```

When calling this route the content page published_at date will be updated according to publish_at and depublish_at fields.

```graphql
  mutation publishContentPages($now: timestamptz, $publishedAt: timestamptz) {
    publish_content_pages: update_app_content(
      where: {
        _or: [
          {publish_at: {_lte: $now, _is_null: false}, depublish_at: {_gte: $now, _is_null: false}},
          {publish_at: {_lte: $now, _is_null: false}, depublish_at: {_is_null: true}},
          {publish_at: {_is_null: true}, published_at: {_gte: $now, _is_null: false}}
        ],
        published_at: {_is_null: true}
      },
      _set: {published_at: $publishedAt}
    ) {
      affected_rows
    }
    unpublish_content_pages: update_app_content(
      where: {
        depublish_at: {_lt: $now, _is_null: false},
        published_at: {_is_null: false}
      },
      _set: {published_at: null}
    ) {
      affected_rows
    }
  }
```