### PR TITLE
fix(hetarchief-service): disable certificate check for localhost SAML

### DIFF
--- a/server/src/modules/auth/idps/hetarchief/service.ts
+++ b/server/src/modules/auth/idps/hetarchief/service.ts
@@ -145,7 +145,11 @@ export default class HetArchiefService {
 				{
 					request_body: requestBody,
 					allow_unencrypted_assertion: true,
-				},
+
+					// https://github.com/Clever/saml2/issues/106
+					ignore_signature: process.env.NODE_ENV === 'local',
+					require_session_index: !(process.env.NODE_ENV === 'local'),
+				} as any,
 				(err, samlResponse: DecodedSamlResponse) => {
 					if (err) {
 						reject(


### PR DESCRIPTION
workaround for error:
Error: SAML Assertion signature check failed! (checked 1 certificate(s))