### PR TITLE
fix(auth-hetarchief-controller): allow multiple companies with oormerk

### DIFF
--- a/server/src/modules/auth/idps/hetarchief/controller.ts
+++ b/server/src/modules/auth/idps/hetarchief/controller.ts
@@ -262,17 +262,14 @@ export default class HetArchiefController {
 			};
 		}) as any[];
 
-		await promiseUtils.mapLimit(orgIds, 2, async (orgId: string) => {
-			// Check if org has type "School" or "Internaat" or something else
-			// if something else => set that as the business category
+		// Store business category of first organisation
+		if (orgIds.length) {
 			const orgInfo = await EducationOrganizationsService.getOrganization(
-				orgId,
-				orgUnitIds.find(orgUnitId => orgUnitId.startsWith(orgId)),
+				orgIds[0],
+				orgUnitIds.find(orgUnitId => orgUnitId.startsWith(orgIds[0])),
 			);
-			if (orgInfo.type !== 'School' && orgInfo.type !== 'Internaat') {
-				(newAvoUser.profile as any).business_category = orgInfo.type;
-			}
-		});
+			(newAvoUser.profile as any).business_category = orgInfo.type;
+		}
 
 		if (!isEqual(newAvoUser, avoUserInfo)) {
 			// Something changes => save to database


### PR DESCRIPTION
closes: https://meemoo.atlassian.net/browse/AVO-1332

now all required fields should be synced in both directions.
acm => avo:
![image](https://user-images.githubusercontent.com/1710840/100722596-10e3c780-33c1-11eb-96c8-bb6fbaa5c99b.png)

avo => acm
![image](https://user-images.githubusercontent.com/1710840/100722619-16d9a880-33c1-11eb-896e-1b37261eeac3.png)
