### PR TITLE
fix(hetarchief-controller): is_blocked follows avo app in ACM

### DIFF
--- a/server/src/modules/auth/idps/hetarchief/controller.ts
+++ b/server/src/modules/auth/idps/hetarchief/controller.ts
@@ -245,7 +245,7 @@ export default class HetArchiefController {
 		(newAvoUser.profile as any).is_exception =
 			get(ldapUserInfo, 'exception_account[0]') === 'TRUE';
 
-		newAvoUser.is_blocked = newAvoUser.is_blocked || !ldapUserInfo.apps.find((app) => app.name === 'avo');
+		newAvoUser.is_blocked = !ldapUserInfo.apps.find((app) => app.name === 'avo');
 
 		const orgIds: string[] =
 			get(ldapUserInfo, 'educationalOrganisationIds') ||


### PR DESCRIPTION
closes: https://meemoo.atlassian.net/browse/AVO-1461

Client PR: https://github.com/viaacode/avo2-client/pull/1145

This mainly fixes this scenario:
* getest met ineke.vandam+1
* via acm AVO app verwijderd+syncen
* aanmelden lukt niet op avo
* via acm AVO app terug toevoegen + syncen
* aanmelden lukt niet op avo