### PR TITLE
feat(not-found-route): add route to serve true 404 page for client

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -4010,6 +4010,15 @@
         }
       }
     },
+    "call-bind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
+      "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.2"
+      }
+    },
     "callsites": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-1.0.1.tgz",
@@ -4616,6 +4625,14 @@
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
       "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ=="
     },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "requires": {
+        "object-keys": "^1.0.12"
+      }
+    },
     "define-property": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
@@ -4967,6 +4984,39 @@
           "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
           "dev": true
         }
+      }
+    },
+    "es-abstract": {
+      "version": "1.18.3",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.3.tgz",
+      "integrity": "sha512-nQIr12dxV7SSxE6r6f1l3DtAeEYdsGpps13dR0TwJg1S8gyp4ZPgy3FZcHBgbiQqnoqSTb+oC+kO4UQ0C/J8vw==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "es-to-primitive": "^1.2.1",
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.2",
+        "is-callable": "^1.2.3",
+        "is-negative-zero": "^2.0.1",
+        "is-regex": "^1.1.3",
+        "is-string": "^1.0.6",
+        "object-inspect": "^1.10.3",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.2",
+        "string.prototype.trimend": "^1.0.4",
+        "string.prototype.trimstart": "^1.0.4",
+        "unbox-primitive": "^1.0.1"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
       }
     },
     "es5-ext": {
@@ -5658,8 +5708,7 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-      "dev": true
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "gensync": {
       "version": "1.0.0-beta.2",
@@ -5671,6 +5720,16 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+    },
+    "get-intrinsic": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.1.tgz",
+      "integrity": "sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      }
     },
     "get-package-type": {
       "version": "0.1.0",
@@ -5800,16 +5859,25 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
+    },
+    "has-bigints": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.1.tgz",
+      "integrity": "sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA=="
     },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
+    },
+    "has-symbols": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
+      "integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw=="
     },
     "has-value": {
       "version": "1.0.0",
@@ -6145,6 +6213,11 @@
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
       "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
     },
+    "is-bigint": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.2.tgz",
+      "integrity": "sha512-0JV5+SOCQkIdzjBK9buARcV804Ddu7A0Qet6sHi3FimE9ne6m4BGQZfRn+NZiXbBk4F4XmHfDZIipLj9pX8dSA=="
+    },
     "is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -6154,11 +6227,24 @@
         "binary-extensions": "^2.0.0"
       }
     },
+    "is-boolean-object": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.1.tgz",
+      "integrity": "sha512-bXdQWkECBUIAcCkeH1unwJLIpZYaa5VvuygSyS/c2lf719mTKZDU5UdDRlpd01UjADgmW8RfqaP+mRaVPdr/Ng==",
+      "requires": {
+        "call-bind": "^1.0.2"
+      }
+    },
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "dev": true
+    },
+    "is-callable": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.3.tgz",
+      "integrity": "sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ=="
     },
     "is-ci": {
       "version": "3.0.0",
@@ -6197,6 +6283,11 @@
           }
         }
       }
+    },
+    "is-date-object": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.4.tgz",
+      "integrity": "sha512-/b4ZVsG7Z5XVtIxs/h9W8nvfLgSAyKYdtGWQLbqy6jA1icmgjf8WCoTKgeS4wy5tYaPePouzFMANbnj94c2Z+A=="
     },
     "is-descriptor": {
       "version": "0.1.6",
@@ -6263,6 +6354,11 @@
         }
       }
     },
+    "is-negative-zero": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.1.tgz",
+      "integrity": "sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w=="
+    },
     "is-number": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
@@ -6282,6 +6378,11 @@
           }
         }
       }
+    },
+    "is-number-object": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.5.tgz",
+      "integrity": "sha512-RU0lI/n95pMoUKu9v1BZP5MBcZuNSVJkMkAG2dJqC4z2GlkGUNeH68SuHuBKBD/XFe+LHZ+f9BKkLET60Niedw=="
     },
     "is-plain-object": {
       "version": "2.0.4",
@@ -6303,10 +6404,32 @@
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
       "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ=="
     },
+    "is-regex": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.3.tgz",
+      "integrity": "sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "has-symbols": "^1.0.2"
+      }
+    },
     "is-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
       "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
+    },
+    "is-string": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.6.tgz",
+      "integrity": "sha512-2gdzbKUuqtQ3lYNrUTQYoClPhm7oQu4UdpSZMp1/DGgkHBT8E2Z1l0yMdb6D4zNAxwDiMv8MdulKROJGNl0Q0w=="
+    },
+    "is-symbol": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
+      "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
+      "requires": {
+        "has-symbols": "^1.0.2"
+      }
     },
     "is-typedarray": {
       "version": "1.0.0",
@@ -11256,6 +11379,16 @@
         }
       }
     },
+    "object-inspect": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.10.3.tgz",
+      "integrity": "sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw=="
+    },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+    },
     "object-visit": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
@@ -11263,6 +11396,17 @@
       "dev": true,
       "requires": {
         "isobject": "^3.0.0"
+      }
+    },
+    "object.assign": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+      "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+      "requires": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3",
+        "has-symbols": "^1.0.1",
+        "object-keys": "^1.1.1"
       }
     },
     "object.pick": {
@@ -13038,6 +13182,37 @@
       "resolved": "https://registry.npmjs.org/string-trim-spaces-only/-/string-trim-spaces-only-2.8.23.tgz",
       "integrity": "sha512-MQAksLUGqogkq8qjDBjsASojgEZUZKU2S+cYvH0u9yXrJUWUih9YuNfFK0RtIxSiRvS/dPg9V44dR8GO4nEn5w=="
     },
+    "string.prototype.replaceall": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/string.prototype.replaceall/-/string.prototype.replaceall-1.0.5.tgz",
+      "integrity": "sha512-YUjdWElI9pgKo7mrPOMKHFZxcAa0v1uqoJkMHtlJW63rMkPLkQH71ao2XNkKY2ksHKHC8ZUFwNjN9Vry+QyCvg==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.18.0-next.2",
+        "get-intrinsic": "^1.1.1",
+        "has-symbols": "^1.0.1",
+        "is-regex": "^1.1.2"
+      }
+    },
+    "string.prototype.trimend": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz",
+      "integrity": "sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      }
+    },
+    "string.prototype.trimstart": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz",
+      "integrity": "sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==",
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3"
+      }
+    },
     "string_decoder": {
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
@@ -13831,6 +14006,17 @@
         "random-bytes": "~1.0.0"
       }
     },
+    "unbox-primitive": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
+      "integrity": "sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==",
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has-bigints": "^1.0.1",
+        "has-symbols": "^1.0.2",
+        "which-boxed-primitive": "^1.0.2"
+      }
+    },
     "underscore": {
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.1.tgz",
@@ -14081,6 +14267,18 @@
       "dev": true,
       "requires": {
         "isexe": "^2.0.0"
+      }
+    },
+    "which-boxed-primitive": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
+      "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
+      "requires": {
+        "is-bigint": "^1.0.1",
+        "is-boolean-object": "^1.1.0",
+        "is-number-object": "^1.0.4",
+        "is-string": "^1.0.5",
+        "is-symbol": "^1.0.3"
       }
     },
     "winston": {

--- a/server/package.json
+++ b/server/package.json
@@ -79,6 +79,7 @@
 		"simple-oauth2": "^3.0.1",
 		"srt-to-vtt": "^1.1.3",
 		"string-strip-html": "^5.0.1",
+		"string.prototype.replaceall": "^1.0.5",
 		"swagger-express-ts": "1.0.1",
 		"swagger-ui-express": "4.1.5",
 		"typescript-rest": "3.0.2",

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -19,6 +19,7 @@ import HetArchiefRoute from './modules/auth/idps/het-archief/het-archief.route';
 import HetArchiefService from './modules/auth/idps/het-archief/het-archief.service';
 import KlascementRoute from './modules/auth/idps/klascement/route';
 import KlascementService from './modules/auth/idps/klascement/service';
+import NotFoundRoute from './modules/not-found/not-found.route';
 import SmartschoolRoute from './modules/auth/idps/smartschool/route';
 import SmartschoolService from './modules/auth/idps/smartschool/service';
 import DataService from './modules/data/data.service';
@@ -157,6 +158,7 @@ export class App {
 			UserRoute,
 			NavigationItemsRoute,
 			ContentPagesRoute,
+			NotFoundRoute,
 			PlayerTicketRoute,
 			VideoStillsRoute,
 			StamboekRoute,

--- a/server/src/libs.d.ts
+++ b/server/src/libs.d.ts
@@ -1,1 +1,2 @@
 declare module 'srt-to-vtt';
+declare module 'string.prototype.replaceall';

--- a/server/src/modules/not-found/404.html
+++ b/server/src/modules/not-found/404.html
@@ -136,7 +136,7 @@
 
 	.c-button.c-button--primary {
 		border: 1px solid #25a4cf;
-		background: #25a4cf;
+		background-color: #25a4cf;
 		color: #fff
 	}
 
@@ -145,13 +145,13 @@
 	}
 
 	.c-button.c-button--primary:active, .c-button.c-button--primary:active:focus, .c-button.c-button--primary:hover {
-		background: #19718e;
+		background-color: #19718e;
 		border-color: #19718e
 	}
 
 	.c-button.c-button--danger {
 		border: 1px solid #da3f34;
-		background: #da3f34;
+		background-color: #da3f34;
 		color: #fff
 	}
 
@@ -160,12 +160,12 @@
 	}
 
 	.c-button.c-button--danger:active, .c-button.c-button--danger:focus, .c-button.c-button--danger:hover {
-		background: #b92c22;
+		background-color: #b92c22;
 		border-color: #b92c22
 	}
 
 	.c-button.c-button--danger:disabled, .c-button.c-button--primary:disabled {
-		background: #d6dee3;
+		background-color: #d6dee3;
 		color: #9cafbd;
 		border: 1px solid #d6dee3;
 		pointer-events: auto;
@@ -173,7 +173,7 @@
 	}
 
 	.c-blankslate {
-		background: #edeff2;
+		background-color: #edeff2;
 		border-radius: .3rem;
 		padding: 4.8rem;
 		text-align: center
@@ -236,7 +236,7 @@
 	}
 
 	.o-container-vertical--bg-alt {
-		background: #edeff2
+		background-color: #edeff2
 	}
 
 	.c-meta-data-item--icon .o-svg-icon {
@@ -256,7 +256,7 @@
 	}
 
 	.c-navbar--inverse {
-		background: #314b5e
+		background-color: #314b5e
 	}
 
 	.c-navbar--fixed {
@@ -298,7 +298,7 @@
 	}
 
 	.c-nav__item:focus, .c-nav__item:hover {
-		background: #edeff2;
+		background-color: #edeff2;
 		color: #2b414f
 	}
 
@@ -307,7 +307,7 @@
 	}
 
 	.c-nav__item--i:focus, .c-nav__item--i:hover {
-		background: #436580;
+		background-color: #436580;
 		color: #fff
 	}
 
@@ -468,7 +468,7 @@
 		font-size: 1.5rem;
 		line-height: 1.5;
 		color: #2b414f;
-		background: #fff
+		background-color: #fff
 	}
 
 	img {
@@ -573,7 +573,7 @@
 	}
 
 	.c-navbar--inverse {
-		background: #314b5e
+		background-color: #314b5e
 	}
 
 	.c-navbar--fixed {
@@ -638,7 +638,7 @@
 		}
 
 		.c-blankslate {
-			background: #edeff2;
+			background-color: #edeff2;
 			border-radius: .3rem;
 			padding: 1.8rem;
 			text-align: center;

--- a/server/src/modules/not-found/404.html
+++ b/server/src/modules/not-found/404.html
@@ -1,0 +1,674 @@
+<html lang="nl">
+<head>
+	<title>Pagina niet gevonden | Het Archief voor Onderwijs</title>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width,initial-scale=1">
+	<link rel="shortcut icon" href="{{client-url}}/favicon.ico">
+	<style>
+	.o-svg-icon {
+		display: inline-block;
+		width: 2rem;
+		height: 2rem;
+		vertical-align: middle
+	}
+
+	.o-svg-icon svg {
+		display: block;
+		height: 100%;
+		width: 100%
+	}
+
+	.o-svg-icon:not([class*=multicolor]) svg * {
+		fill: currentColor
+	}
+
+	.o-svg-icon--large {
+		width: 3.2rem;
+		height: 3.2rem
+	}
+
+	.c-toolbar {
+		width: 100%;
+		display: flex;
+		flex-shrink: 0;
+		align-items: center;
+		justify-content: space-between;
+		min-height: 6.4rem
+	}
+
+	.c-toolbar__left {
+		justify-content: flex-start
+	}
+
+	.c-toolbar__left .c-toolbar__item {
+		margin-right: 1.6rem
+	}
+
+	.c-toolbar__left .c-toolbar__item:only-child {
+		margin: 0
+	}
+
+	.c-toolbar__right .c-toolbar__item {
+		margin-left: 1.6rem
+	}
+
+	.c-toolbar__right .c-toolbar__item:only-child {
+		margin: 0
+	}
+
+	.c-toolbar__center {
+		position: absolute;
+		margin-left: 50%;
+		left: 0
+	}
+
+	.c-toolbar__center-inner {
+		margin-left: -50%;
+		display: flex;
+		flex: 1 0 auto;
+		align-items: center
+	}
+
+	.c-toolbar__center-inner .c-toolbar__item {
+		margin: 0 .8rem
+	}
+
+	.c-toolbar__center-inner .c-toolbar__item:only-child {
+		margin: 0
+	}
+
+	.c-toolbar__item {
+		position: relative
+	}
+
+	.c-button {
+		text-decoration: none;
+		cursor: pointer;
+		vertical-align: middle;
+		border-radius: .3rem;
+		padding: .6rem 1.6rem;
+		max-height: 3.6rem;
+		font-size: 1.5rem;
+		text-align: center;
+		align-items: center;
+		font-weight: 400
+	}
+
+	a.c-button {
+		display: inline-flex;
+		justify-content: center
+	}
+
+	.c-button {
+		-webkit-appearance: none;
+		-moz-appearance: none;
+		appearance: none;
+		margin: 0
+	}
+
+	.c-button::-moz-focus-inner {
+		border: 0;
+		padding: 0
+	}
+
+	.c-button .c-button__content {
+		align-items: center;
+		display: flex;
+		justify-content: center
+	}
+
+	.c-button__label {
+		line-height: 2.4rem;
+		white-space: nowrap
+	}
+
+	.c-button + .c-button {
+		margin-left: 1rem;
+	}
+
+	.c-button {
+		padding: .6rem 2rem;
+	}
+
+	.c-button {
+		transition: background .18s ease-in
+	}
+
+	.c-button.c-button--primary {
+		border: 1px solid #25a4cf;
+		background: #25a4cf;
+		color: #fff
+	}
+
+	.c-button.c-button--primary svg * {
+		fill: #fff
+	}
+
+	.c-button.c-button--primary:active, .c-button.c-button--primary:active:focus, .c-button.c-button--primary:hover {
+		background: #19718e;
+		border-color: #19718e
+	}
+
+	.c-button.c-button--danger {
+		border: 1px solid #da3f34;
+		background: #da3f34;
+		color: #fff
+	}
+
+	.c-button.c-button--danger svg * {
+		fill: #fff
+	}
+
+	.c-button.c-button--danger:active, .c-button.c-button--danger:focus, .c-button.c-button--danger:hover {
+		background: #b92c22;
+		border-color: #b92c22
+	}
+
+	.c-button.c-button--danger:disabled, .c-button.c-button--primary:disabled {
+		background: #d6dee3;
+		color: #9cafbd;
+		border: 1px solid #d6dee3;
+		pointer-events: auto;
+		cursor: default
+	}
+
+	.c-blankslate {
+		background: #edeff2;
+		border-radius: .3rem;
+		padding: 4.8rem;
+		text-align: center
+	}
+
+	.c-blankslate__icon {
+		display: flex;
+		justify-content: center;
+		align-items: center;
+		width: 9.6rem;
+		height: 9.6rem;
+		background-color: #cfe3e9;
+		border-radius: 50%;
+		margin: 0 auto
+	}
+
+	.c-blankslate__icon svg {
+		color: #25a4cf
+	}
+
+	.c-blankslate > .c-h4 {
+		margin-bottom: .8rem
+	}
+
+	.c-blankslate > .o-svg-icon {
+		opacity: .5
+	}
+
+	.o-container {
+		margin: 0 auto;
+		max-width: 130rem;
+		width: calc(100% - 2.4rem)
+	}
+
+	@media (min-width: 700px) {
+		.o-container {
+			width: calc(100% - 3.2rem)
+		}
+	}
+
+	@media (min-width: 900px) {
+		.o-container {
+			width: calc(100% - 4.8rem)
+		}
+	}
+
+	@media (min-width: 1200px) {
+		.o-container {
+			width: calc(100% - 6.4rem)
+		}
+	}
+
+	.o-container--medium {
+		max-width: 72rem;
+		padding: 0 5px
+	}
+
+	.o-container-vertical {
+		padding: 3.6rem 0
+	}
+
+	.o-container-vertical--bg-alt {
+		background: #edeff2
+	}
+
+	.c-meta-data-item--icon .o-svg-icon {
+		width: 1.4rem;
+		height: 1.4rem;
+		margin-right: .4rem
+	}
+
+	.c-image img {
+		display: block;
+		margin: 0 auto
+	}
+
+	.c-navbar {
+		height: 6.4rem;
+		width: 100%
+	}
+
+	.c-navbar--inverse {
+		background: #314b5e
+	}
+
+	.c-navbar--fixed {
+		position: fixed;
+		top: 0
+	}
+
+	.c-navbar--fixed {
+		left: 0;
+		z-index: 30;
+		box-shadow: 0 0 .8rem 0 rgba(69, 100, 123, .35)
+	}
+
+	.c-navbar--bordered-bottom {
+		border-bottom: .1rem solid #d6dee3
+	}
+
+	.c-navbar--bordered-bottom.c-navbar--inverse {
+		border-bottom: .1rem solid #283d4e;
+		box-shadow: none
+	}
+
+	.c-nav ul {
+		margin: 0;
+		padding: 0
+	}
+
+	.c-nav li {
+		display: inline-block;
+		margin-right: .4rem
+	}
+
+	.c-nav__item {
+		display: block;
+		padding: .8rem 1.6rem;
+		color: #385265;
+		text-decoration: none;
+		border-radius: .3rem
+	}
+
+	.c-nav__item:focus, .c-nav__item:hover {
+		background: #edeff2;
+		color: #2b414f
+	}
+
+	.c-nav__item--i {
+		color: #fff
+	}
+
+	.c-nav__item--i:focus, .c-nav__item--i:hover {
+		background: #436580;
+		color: #fff
+	}
+
+	.c-nav.c-nav .o-svg-icon {
+		width: 1.8rem;
+		height: 1.8rem;
+		position: relative;
+		bottom: .2rem
+	}
+
+	.c-nav.c-nav .o-svg-icon * {
+		fill: #557891
+	}
+
+	.c-nav.c-nav .o-svg-icon + span {
+		width: 1.8rem;
+		height: 1.8rem;
+		position: relative;
+		margin-left: .75rem
+	}
+
+	.c-nav.c-nav .o-svg-icon + span * {
+		fill: #557891
+	}
+
+	.c-global-footer {
+		border-top: 1px solid #d6dee3;
+		padding: 2.4rem 0;
+		margin-top: auto;
+		font-size: 1.3rem;
+		color: #45647b
+	}
+
+	.c-global-footer a {
+		display: flex;
+		align-items: center;
+		color: #45647b;
+		text-decoration: none;
+		padding: 0;
+		box-sizing: border-box;
+		margin-bottom: 1px
+	}
+
+	.c-global-footer a:hover {
+		border-bottom: 1px solid #9cafbd;
+		margin-bottom: 0
+	}
+
+	.c-global-footer a img {
+		height: 35px;
+		transform: translate(0, 3px)
+	}
+
+	.c-global-footer ul li {
+		padding: .4rem;
+		display: inline-block;
+		margin-right: .8rem
+	}
+
+	.c-global-footer .c-nav__item--i {
+		color: #45647b
+	}
+
+	.c-global-footer .c-nav__item--i:focus, .c-global-footer .c-nav__item--i:hover {
+		background: 0 0;
+		color: #45647b
+	}
+
+	@media (min-width: 700px) {
+		.c-global-footer__inner {
+			display: flex;
+			justify-content: space-between
+		}
+	}
+
+	@keyframes flash {
+		50%, from, to {
+			background-color: #9fdaee
+		}
+		25%, 75% {
+			background-color: #fff
+		}
+	}
+
+	.c-item-view__main .c-button-toolbar .c-button + .c-button {
+		margin-left: 0
+	}
+
+	.c-item-view__main .c-button-toolbar .c-button {
+		margin-bottom: .8rem
+	}
+
+	.c-item-view__main .c-button-toolbar .c-button:not(:last-child) {
+		margin-right: .8rem
+	}
+
+	@media (max-width: 700px) {
+		.c-search-view .c-navbar {
+			min-height: 13rem
+		}
+	}
+
+	a, b, body, center, div, footer, h1, h2, h3, h4, h5, h6, html, i, iframe, img, label, li, nav, s, span, u, ul, var {
+		margin: 0;
+		padding: 0;
+		border: 0;
+		font-size: 100%;
+		vertical-align: baseline
+	}
+
+	footer, nav {
+		display: block
+	}
+
+	body {
+		line-height: 1
+	}
+
+	ul {
+		list-style: none
+	}
+
+	#launcher {
+		bottom: 100px !important
+	}
+
+	.o-app > .o-container {
+		overflow-x: hidden
+	}
+
+	*, :after, :before {
+		box-sizing: border-box
+	}
+
+	body, html {
+		overflow-x: hidden
+	}
+
+	html {
+		font-size: 54.16%
+	}
+
+	@media (min-width: 900px) {
+		html {
+			font-size: 58.33%
+		}
+	}
+
+	@media (min-width: 1200px) {
+		html {
+			font-size: 62.5%
+		}
+	}
+
+	body {
+		position: relative;
+		font-family: Montserrat, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+		font-size: 1.5rem;
+		line-height: 1.5;
+		color: #2b414f;
+		background: #fff
+	}
+
+	img {
+		max-width: 100%
+	}
+
+	button {
+		font-family: inherit;
+		font-size: inherit
+	}
+
+	a {
+		color: #25a4cf
+	}
+
+	i {
+		font-style: italic
+	}
+
+	b {
+		font-weight: 500
+	}
+
+	.o-app {
+		display: flex;
+		flex-direction: column;
+		min-height: 100vh;
+		padding-top: 6.4rem
+	}
+
+	.o-app > .c-navbar {
+		max-width: 100vw
+	}
+
+	.c-brand {
+		width: 14.3rem;
+		height: 2.9rem
+	}
+
+	.c-brand a, .c-brand img {
+		display: block;
+		height: 100%;
+		width: 100%
+	}
+
+	.c-navbar .c-brand {
+		margin-right: 1.2rem;
+		position: relative;
+		bottom: .3rem
+	}
+
+	.c-content-type .o-svg-icon {
+		margin-right: .4rem;
+		width: 1.8rem;
+		height: 1.8rem
+	}
+
+	.c-content h4, .c-h4 {
+		font-family: Montserrat, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+		font-size: 1.5rem;
+		font-weight: 500;
+		margin: 1.5rem 0
+	}
+
+	.c-content--no-m > :first-child, .c-content--no-m > :only-child {
+		margin: 0
+	}
+
+	.c-content a {
+		text-decoration: underline
+	}
+
+	.c-content ul {
+		padding: 0;
+		margin: 1.5rem 0 1.5rem 1.75rem
+	}
+
+	.c-content ul ul {
+		margin: 0;
+		padding-left: 2.25rem
+	}
+
+	.c-content ul ul li {
+		list-style: circle
+	}
+
+	.c-content ul {
+		list-style: disc
+	}
+
+	.c-content li {
+		padding-left: .5rem
+	}
+
+	.c-content .c-button {
+		text-decoration: none
+	}
+
+	.c-navbar {
+		height: 6.4rem;
+		width: 100%
+	}
+
+	.c-navbar--inverse {
+		background: #314b5e
+	}
+
+	.c-navbar--fixed {
+		position: fixed;
+		top: 0;
+		left: 0;
+		z-index: 30;
+		box-shadow: 0 0 .8rem 0 rgba(69, 100, 123, .35)
+	}
+
+	.c-navbar--bordered-bottom {
+		border-bottom: .1rem solid #d6dee3
+	}
+
+	.c-navbar--bordered-bottom.c-navbar--inverse {
+		border-bottom: .1rem solid #283d4e;
+		box-shadow: none
+	}
+
+	.u-spacer-left-s {
+		margin-left: .8rem !important
+	}
+
+	.u-spacer-bottom-l {
+		margin-bottom: 2.4rem !important
+	}
+
+	@media (max-width: 700px) {
+		.c-toolbar {
+			position: relative;
+			width: auto;
+			display: block;
+		}
+
+		.c-toolbar__center {
+			position: relative;
+			left: 0;
+			margin-left: 0;
+			width: 100%;
+		}
+
+		.c-toolbar__center-inner {
+			position: relative;
+			margin-left: 0;
+			width: 100%;
+			display: block;
+			flex: none;
+		}
+
+		.c-button-toolbar {
+			width: 100%;
+		}
+
+		.c-button {
+			display: block;
+			width: 100%;
+			margin: 10px auto;
+		}
+
+		.c-button + .c-button {
+			margin-left: 0;
+		}
+
+		.c-blankslate {
+			background: #edeff2;
+			border-radius: .3rem;
+			padding: 1.8rem;
+			text-align: center;
+		}
+
+		.c-brand {
+			margin-top: 17px;
+		}
+
+		#launcher {
+			bottom: 115px !important;
+		}
+	}
+</style>
+</head>
+<body><noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MNSTNVJ" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript><div id="root"><div class="o-app"><div class="c-navbar c-navbar--bordered-bottom c-navbar--fixed c-navbar--inverse"><div class="o-container"><div class="c-toolbar"><div class="c-toolbar__left"><div class="c-toolbar__item"><h1 class="c-brand"><a href="{{client-url}}/"><img class="c-brand__image" src="{{client-url}}/images/avo-logo-i.svg" alt="Logo Het Archief voor Onderwijs"></a></h1></div></div></div></div></div><div class="m-error-view o-container-vertical o-container-vertical--bg-alt"><div class="o-container o-container--medium"><div class="c-blankslate"><div class="u-spacer-bottom-l"><div class="c-blankslate__icon"><div class="o-svg-icon o-svg-icon--search o-svg-icon--large"><svg width="24" height="24" viewBox="0 0 24 24" fill="none"><path d="M11 20c-4.962 0-9-4.037-9-9 0-4.962 4.038-9 9-9 4.963 0 9 4.038 9 9 0 4.963-4.037 9-9 9zm0-16c-3.86 0-7 3.14-7 7 0 3.859 3.14 7 7 7 3.859 0 7-3.141 7-7 0-3.86-3.141-7-7-7z" fill="#000"></path><path d="M21 22a.997.997 0 01-.707-.293l-4.35-4.35a.999.999 0 111.414-1.414l4.35 4.35A.999.999 0 0121 22z" fill="#000"></path></svg></div></div></div><h4 class="c-h4">{{message}}</h4>
+
+
+	<div class="c-toolbar"><div class="c-toolbar__center"><div class="c-toolbar__center-inner">
+
+	<div class="c-button-toolbar">
+		<a href="{{client-url}}/" class="c-button c-button--primary">
+			<div class="c-button__content">
+				<div class="c-button__label">Ga terug naar de startpagina</div>
+			</div>
+		</a>
+		<button class="c-button c-button--danger" onclick="window.zE('webWidget','toggle')"><span class="c-button__content"><span class="c-button__label">Contacteer onze helpdesk</span></span>
+		</button>
+	</div>
+
+</div></div></div></div></div></div><footer class="c-global-footer"><div class="c-global-footer__inner o-container"><ul><li><a href="https://meemoo.be/nl" title="meemoo"><span class="c-nav__item-label">Een initiatief van</span><div class="u-spacer-left-s"><img src="{{client-url}}/images/meemoo-logo.png" alt="Logo van meemoo"></div></a></li><li><a class="c-nav__item c-nav__item--i" href="{{client-url}}/hulp"><span class="c-nav__item-label">Gebruiksvoorwaarden</span></a></li><li><a class="c-nav__item c-nav__item--i" href="{{client-url}}/privacy"><span class="c-nav__item-label">Privacyverklaring</span></a></li><li><a class="c-nav__item c-nav__item--i" href="{{client-url}}/cookiebeleid"><span class="c-nav__item-label">Cookieverklaring</span></a></li></ul><ul><li><a class="c-nav__item c-nav__item--i" title="Hulp" href="{{client-url}}/hulp"></a></li><li><a href="https://www.vlaanderen.be/" title="Vlaamse Overheid"><span class="c-nav__item-label">Gesteund door</span><div class="u-spacer-left-s"><img src="{{client-url}}/images/vlaanderen-logo.png" alt="Logo van de Vlaamse Overheid"></div></a></li></ul></div></footer></div></div>
+<script src="{{client-url}}/old-browser-detector.min.js" type="text/javascript"></script><script type="text/javascript">var Detector=new oldBrowserDetector(null,function(){window.open("/unsupported-browser.html")});Detector.detect();</script>
+<script async id="ze-snippet" src="https://static.zdassets.com/ekr/snippet.js?key=6bfc8294-ce0c-4e40-92de-35b855c49a84"></script><iframe data-product="web_widget" title="No content" tabindex="-1" aria-hidden="true" src="about:blank" style="width:0;height:0;border:0;position:absolute;top:-9999px"></iframe><div><iframe title="Opens a widget where you can find more information" id="launcher" tabindex="0" style="width:143px;height:50px;padding:0;margin:10px 20px 107px;position:fixed;bottom:0;overflow:visible;opacity:1;border:0;z-index:999998;transition-duration:250ms;transition-timing-function:cubic-bezier(.645,.045,.355,1);transition-property:opacity,top,bottom;right:0"></iframe></div></body></html>

--- a/server/src/modules/not-found/not-found.route.ts
+++ b/server/src/modules/not-found/not-found.route.ts
@@ -19,7 +19,7 @@ export default class NotFoundRoute {
 		if (!this.notFoundHtml) {
 			this.notFoundHtml = (
 				await fs.readFile(path.resolve('src/modules/not-found/404.html'))
-			).toString('utf-8');
+			).toString('utf8');
 			this.notFoundHtml = replaceAll(
 				this.notFoundHtml,
 				'{{client-url}}',
@@ -27,7 +27,7 @@ export default class NotFoundRoute {
 			);
 		}
 		this.context.response.status(404);
-		this.context.response.setHeader('Content-Type', 'text/html');
+		this.context.response.setHeader('Content-Type', 'text/html; charset=utf-8');
 		this.context.response.send(
 			this.notFoundHtml.replace(
 				'{{message}}',

--- a/server/src/modules/not-found/not-found.route.ts
+++ b/server/src/modules/not-found/not-found.route.ts
@@ -1,0 +1,38 @@
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import replaceAll from 'string.prototype.replaceall';
+import { Context, GET, Path, QueryParam, ServiceContext } from 'typescript-rest';
+
+@Path('/not-found')
+export default class NotFoundRoute {
+	@Context
+	context: ServiceContext;
+
+	private notFoundHtml: string;
+
+	/**
+	 * Returns a static 404 page that resembles the avo page with a true 404 status code
+	 */
+	@Path('/')
+	@GET
+	async serve404Page(@QueryParam('message') message: string): Promise<void> {
+		if (!this.notFoundHtml) {
+			this.notFoundHtml = (
+				await fs.readFile(path.resolve('src/modules/not-found/404.html'))
+			).toString('utf-8');
+			this.notFoundHtml = replaceAll(
+				this.notFoundHtml,
+				'{{client-url}}',
+				process.env.CLIENT_HOST
+			);
+		}
+		this.context.response.status(404);
+		this.context.response.setHeader('Content-Type', 'text/html');
+		this.context.response.send(
+			this.notFoundHtml.replace(
+				'{{message}}',
+				message || 'Oeps. Deze pagina is niet toegankelijk.'
+			)
+		);
+	}
+}


### PR DESCRIPTION
part of: https://meemoo.atlassian.net/browse/AVO-1657

When the client detects a route that doesn't exist, it can redirect the browser to the /not-found route on the server. Which returns a static 404 page with status code: 404 instead of the 200 the client returns

![image](https://user-images.githubusercontent.com/1710840/124970846-baaac700-e028-11eb-9b38-4b59cf4d1e9e.png)

![image](https://user-images.githubusercontent.com/1710840/124970849-bc748a80-e028-11eb-87f8-067c5e3e1140.png)
